### PR TITLE
Fix output of monitor keyring path

### DIFF
--- a/ceph_deploy/new.py
+++ b/ceph_deploy/new.py
@@ -106,7 +106,7 @@ def new(args):
             else:
                 raise
 
-    LOG.debug('Writing monitor keyring to %s...', path)
+    LOG.debug('Writing monitor keyring to %s...', keypath)
     if not args.dry_run:
         tmp = '%s.tmp' % keypath
         with file(tmp, 'w') as f:


### PR DESCRIPTION
Printing the location of the monitor keyring was incorrectly printing the location of {cluster-name}.conf, not {cluster-name}.mon.keyring

Signed-off-by: Travis Rhoden trhoden@gmail.com
