### PR TITLE
Add support for Scientific Linux as a centos target

### DIFF
--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -367,7 +367,7 @@ def install(args):
 
         if (distro == 'Debian' or distro == 'Ubuntu'):
             install_r = sudo.compile(install_debian)
-        elif (distro == 'CentOS') or distro.startswith('RedHat'):
+        elif (distro == 'CentOS' or distro == 'Scientific') or distro.startswith('RedHat'):
             install_r = sudo.compile(install_centos)
         elif distro == 'Fedora':
             install_r = sudo.compile(install_fedora)
@@ -404,7 +404,7 @@ def uninstall(args):
         if (distro == 'Debian' or distro == 'Ubuntu'):
             LOG.debug('Uninstalling on host %s ...', hostname)
             uninstall_r = sudo.compile(uninstall_debian)
-        elif (distro == 'CentOS') or distro.startswith('RedHat'):
+        elif (distro == 'CentOS' or distro == 'Scientific') or distro.startswith('RedHat'):
             LOG.debug('Uninstalling on host %s ...', hostname)
             uninstall_r = sudo.compile(uninstall_centos)
         else:


### PR DESCRIPTION
```
(greg.poirier@oppie)(~/dev/ceph-deploy)(scientific_support)
ceph-deploy install test-ceph-1001 test-ceph-1002 test-ceph-1003

[root@test-ceph-1001 ~]# yum list ceph
Loaded plugins: security
Installed Packages
ceph.x86_64                                                    0.61.2-0.el6                                                     @ceph
[root@test-ceph-1001 ~]# which ceph
/usr/bin/ceph
```

I promise uninstall works too.
