### PR TITLE
Fix install on RPM based distros

### DIFF
--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -70,6 +70,9 @@ def uninstall_suse(arg_purge=False):
 
     packages = [
         'ceph',
+        'libcephfs1',
+        'librados2',
+        'librbd1',
         ]
     args = [
         'zypper',


### PR DESCRIPTION
- remove some not existing packages like ceph-common and ceph-fs-common from the install and uninstall code for SUSE, Fedora and CentOs
- add some lib packages to the uninstall/remove code.
