### PR TITLE
install.py: fix also uninstall on Fedora and CentOS

### DIFF
--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -166,6 +166,9 @@ def uninstall_fedora(arg_purge=False):
 
     packages = [
         'ceph',
+        'libcephfs1',
+        'librados2',
+        'librbd1',
         ]
     args = [
         'yum',
@@ -232,6 +235,9 @@ def uninstall_centos(arg_purge=False):
 
     packages = [
         'ceph',
+        'libcephfs1',
+        'librados2',
+        'librbd1',
         ]
     args = [
         'yum',


### PR DESCRIPTION
Uninstall also lib(cephfs,rados,rbd)\* packages, installed
via package dependencies before.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
