### PR TITLE
remove a no longer relevant assertion for test_install

### DIFF
--- a/ceph_deploy/tests/test_cli_install.py
+++ b/ceph_deploy/tests/test_cli_install.py
@@ -63,4 +63,3 @@ def test_simple(tmpdir):
     assert fake_distro.name == 'Ubuntu'
     assert fake_distro.release == 'precise'
     assert fake_distro.codename == 'cuttlefish'
-    assert fake_distro.sudo_conn.compile.call_count == 1


### PR DESCRIPTION
This assertion fails because with the latest changes on `ceph-deploy install` the callable is, well, no longer called.
