### PR TITLE
for Debian wheezy, install ca-certificates. Decrease verbosity when updating

### DIFF
--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -12,6 +12,21 @@ def install(distro, logger, version_kind, version):
     else:
         key = 'autobuild'
 
+    # Make sure ca-certificates is installed
+    check_call(
+        distro.sudo_conn,
+        logger,
+        [
+            'env',
+            'DEBIAN_FRONTEND=noninteractive',
+            'apt-get',
+            '-q',
+            'install',
+            '--assume-yes',
+            'ca-certificates',
+        ]
+    )
+
     check_call(
         distro.sudo_conn,
         logger,


### PR DESCRIPTION
This fixes an issue when using `ceph-deploy install` on Debian Wheezy, the lack of the `ca-certificates` will not allow the tool to add the keys on the remote host

(fixes 5208)
