### PR TITLE
use the right init script in mon create

### DIFF
--- a/ceph_deploy/hosts/common.py
+++ b/ceph_deploy/hosts/common.py
@@ -31,7 +31,12 @@ def mon_create(distro, logger, args, monitor_keyring, hostname):
     logger.debug('remote hostname: %s' % hostname)
     path = paths.mon.path(args.cluster, hostname)
     done_path = paths.mon.done(args.cluster, hostname)
-    init_path = paths.mon.init(args.cluster, hostname, 'sysvinit')
+    if distro.name.lower() == 'ubuntu':
+        init = 'upstart'
+    else:
+        init = 'sysvinit'
+
+    init_path = paths.mon.init(args.cluster, hostname, init)
 
     configuration = conf.load(args)
     conf_data = StringIO()


### PR DESCRIPTION
mon create was using sysvinit as a default, this changeset makes sure we are doing the right thing for other distros

Fixes: http://tracker.ceph.com/issues/5911
