### PR TITLE
re-raise so we halt execution of remote actions

### DIFF
--- a/ceph_deploy/util/wrappers.py
+++ b/ceph_deploy/util/wrappers.py
@@ -49,5 +49,6 @@ def check_call(conn, logger, args, *a, **kw):
                 for line in err.remote_traceback:
                     if line:
                         logger.error(line)
+                raise RuntimeError('Failed to execute command: %s' % ' '.join(args))
             else:
                 raise err


### PR DESCRIPTION
Because we were not raising in the `check_call` wrapper, it would basically hang waiting for more output. Very very weird issue that made pushy lock onto a thread.

This should not only address 5895 (http://tracker.ceph.com/issues/5895) but should also prevent from further execution of other actions for ceph-deploy.
