### PR TITLE
default to dumpling for installs

### DIFF
--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -317,7 +317,7 @@ def make(parser):
 
     version.set_defaults(
         func=install,
-        stable='cuttlefish',
+        stable='dumpling',
         dev='master',
         version_kind='stable',
         )


### PR DESCRIPTION
Now that we have released dumpling, we should default to that for installs.
