### PR TITLE
use replacepkgs flag to quiet down installtion of epel

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -40,8 +40,6 @@ def install(distro, logger, version_kind, version):
             'rpm',
             '-Uvh',
             '--replacepkgs',
-            '--force',
-            '--quiet',
             '{url}noarch/ceph-release-1-0.el6.noarch.rpm'.format(url=url),
         ],
     )
@@ -79,7 +77,10 @@ def install_epel(distro, logger):
             pkg_managers.rpm(
                 distro.sudo_conn,
                 logger,
-                ['epel-release-6*.rpm'],
+                [
+                    '--replacepkgs',
+                    'epel-release-6*.rpm',
+                ],
                 stop_on_error=False,
             )
         else:
@@ -92,6 +93,9 @@ def install_epel(distro, logger):
             pkg_managers.rpm(
                 distro.sudo_conn,
                 logger,
-                ['epel-release-5*.rpm'],
+                [
+                    '--replacepkgs',
+                    'epel-release-5*.rpm'
+                ],
                 stop_on_error=False,
             )


### PR DESCRIPTION
with this change, we no longer see tracebacks from the remote because we tell rpm to avoid doing a non-zero exit status when replacing the package.

Example output:

```
ceph-deploy install node2
[ceph_deploy.install][DEBUG ] Installing stable version dumpling on cluster ceph hosts node2
[ceph_deploy.install][DEBUG ] Detecting platform for host node2 ...
[ceph_deploy.lsb][WARNIN] lsb_release was not found - inferring OS details
[ceph_deploy.install][INFO  ] Distro info: CentOS 6.3 Final
[node2][INFO  ] installing ceph on node2
[node2][INFO  ] adding EPEL repository
[node2][INFO  ] Running command: wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
[node2][ERROR ] --2013-08-26 15:23:36--  http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
[node2][ERROR ] Resolving dl.fedoraproject.org... 209.132.181.26, 209.132.181.27, 209.132.181.23, ...
[node2][ERROR ] Connecting to dl.fedoraproject.org|209.132.181.26|:80... connected.
[node2][ERROR ] HTTP request sent, awaiting response... 200 OK
[node2][ERROR ] Length: 14540 (14K) [application/x-rpm]
[node2][ERROR ] Saving to: “epel-release-6-8.noarch.rpm.1”
[node2][ERROR ]      0K .......... ....                                       100%  163K=0.09s
[node2][ERROR ] 2013-08-26 15:23:41 (163 KB/s) - “epel-release-6-8.noarch.rpm.1” saved [14540/14540]
[node2][INFO  ] Running command: rpm -Uvh --replacepkgs --force --quiet epel-release-6*.rpm
[node2][INFO  ] ##################################################
[node2][INFO  ] ##################################################
[node2][ERROR ] warning: epel-release-6-8.noarch.rpm: Header V3 RSA/SHA256 Signature, key ID 0608b895: NOKEY
[node2][INFO  ] Running command: su -c 'rpm --import "https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc"'
[node2][INFO  ] Running command: rpm -Uvh --replacepkgs --force --quiet http://ceph.com/rpm-dumpling/el6/noarch/ceph-release-1-0.el6.noarch.rpm
[node2][INFO  ] ##################################################
[node2][INFO  ] ##################################################
[node2][INFO  ] Running command: yum -y -q install ceph
[node2][ERROR ] warning: rpmts_HdrFromFdno: Header V3 RSA/SHA256 Signature, key ID 0608b895: NOKEY
[node2][ERROR ] Importing GPG key 0x0608B895:
[node2][ERROR ]  Userid : EPEL (6) <epel@fedoraproject.org>
[node2][ERROR ]  Package: epel-release-6-8.noarch (installed)
[node2][ERROR ]  From   : /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
[node2][ERROR ] Warning: RPMDB altered outside of yum.
[node2][INFO  ] Running command: ceph --version
[node2][INFO  ] ceph version 0.67.2 (eb4380dd036a0b644c6283869911d615ed729ac8)
```
