### PR TITLE
detect sudo needs and switch connections for any use-case

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -6,7 +6,6 @@ on the type of distribution/version we are dealing with.
 """
 import logging
 from ceph_deploy import exc, lsb
-from ceph_deploy.util import wrappers
 from ceph_deploy.sudo_pushy import get_transport
 from ceph_deploy.hosts import debian, centos, fedora, suse
 
@@ -35,7 +34,8 @@ def get(hostname, fallback=None):
     :param hostname: A hostname that is reachable/resolvable over the network
     :param fallback: Optional fallback to use if no supported distro is found
     """
-    sudo_conn = pushy.connect(get_transport(hostname))
+    transport = get_transport(hostname)
+    sudo_conn = pushy.connect(transport)
     (distro, release, codename) = lsb.get_lsb_release(sudo_conn)
 
     module = _get_distro(distro)

--- a/ceph_deploy/sudo_pushy.py
+++ b/ceph_deploy/sudo_pushy.py
@@ -1,17 +1,22 @@
+import getpass
+import logging
+import socket
 import pushy.transport.ssh
 import pushy.transport.local
-import subprocess 
+import subprocess
+
+logger = logging.getLogger(__name__)
 
 
 class Local_Popen(pushy.transport.local.Popen):
     def __init__(self, command, address, **kwargs):
         pushy.transport.BaseTransport.__init__(self, address)
-    
+
         self.__proc = subprocess.Popen(command, stdin=subprocess.PIPE,
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE,
                                        bufsize=65535)
-    
+
         self.stdout = self.__proc.stdout
         self.stderr = self.__proc.stderr
         self.stdin  = self.__proc.stdin
@@ -19,12 +24,14 @@ class Local_Popen(pushy.transport.local.Popen):
     def close(self):
         self.stdin.close()
         self.__proc.wait()
-    
+
+
 class SshSudoTransport(object):
     @staticmethod
     def Popen(command, *a, **kw):
         command = ['sudo'] + command
         return pushy.transport.ssh.Popen(command, *a, **kw)
+
 
 class LocalSudoTransport(object):
     @staticmethod
@@ -32,14 +39,29 @@ class LocalSudoTransport(object):
         command = ['sudo'] + command
         return Local_Popen(command, *a, **kw)
 
-def get_transport(hostname):
-    import socket
 
+def get_transport(hostname):
+    use_sudo = needs_sudo()
     myhostname = socket.gethostname().split('.')[0]
     if hostname == myhostname:
-        return 'local+sudo:'
+        if use_sudo:
+            logger.debug('will use a local connection with sudo')
+            return 'local+sudo:'
+        logger.debug('will use a local connection without sudo')
+        return 'local:'
     else:
-        return 'ssh+sudo:{hostname}'.format(hostname=hostname)
+        if use_sudo:
+            logger.debug('will use a remote connection with sudo')
+            return 'ssh+sudo:{hostname}'.format(hostname=hostname)
+        logger.debug('will use a remote connection without sudo')
+        return 'ssh:{hostname}'.format(hostname=hostname)
+
+
+def needs_sudo():
+    if getpass.getuser() == 'root':
+        return False
+    return True
+
 
 def patch():
     """


### PR DESCRIPTION
The following changeset detects if a user needs to `sudo` on the remote end by getting the current user. If the current user is the `root` user, then `sudo` is disabled.

This should fix the unnecessary (and sometimes problematic) abuse of sudo that can trigger the sudoers error:

```
sudo: sorry, you must have a tty to run sudo
```

root users do not need sudo.
