### PR TITLE
allow to specify host:fqdn/ip in mon create and destroy

### DIFF
--- a/ceph_deploy/misc.py
+++ b/ceph_deploy/misc.py
@@ -9,3 +9,17 @@ def get_file(path):
     except IOError:
         pass
 
+def mon_hosts(mons):
+    """
+    Iterate through list of MON hosts, return tuples of (name, host).
+    """
+    for m in mons:
+        if m.count(':'):
+            (name, host) = m.split(':')
+        else:
+            name = m
+            host = m
+            if name.count('.') > 0:
+                name = name.split('.')[0]
+        yield (name, host)
+

--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -75,23 +75,23 @@ def mon_create(args):
         )
 
     errors = 0
-    for hostname in args.mon:
+    for (name, host) in mon_hosts(args.mon):
         try:
             # TODO username
             # TODO add_bootstrap_peer_hint
-            LOG.debug('detecting platform for host %s ...', hostname)
-            distro = hosts.get(hostname)
+            LOG.debug('detecting platform for host %s ...', name)
+            distro = hosts.get(host)
             LOG.info('distro info: %s %s %s', distro.name, distro.release, distro.codename)
-            rlogger = logging.getLogger(hostname)
+            rlogger = logging.getLogger(name)
 
             # ensure remote hostname is good to go
-            hostname_is_compatible(distro.sudo_conn, rlogger, hostname)
-            rlogger.debug('deploying mon to %s', hostname)
+            hostname_is_compatible(distro.sudo_conn, rlogger, name)
+            rlogger.debug('deploying mon to %s', name)
             distro.mon.create(distro, rlogger, args, monitor_keyring)
 
             # tell me the status of the deployed mon
             time.sleep(2)  # give some room to start
-            mon_status(distro.sudo_conn, rlogger, hostname)
+            mon_status(distro.sudo_conn, rlogger, name)
             distro.sudo_conn.close()
 
         except RuntimeError as e:
@@ -201,12 +201,12 @@ def destroy_mon(cluster, paths, is_running):
 
 def mon_destroy(args):
     errors = 0
-    for hostname in args.mon:
+    for (name, host) in mon_hosts(args.mon):
         try:
-            LOG.debug('Removing mon from %s', hostname)
+            LOG.debug('Removing mon from %s', name)
 
             # TODO username
-            sudo = args.pushy(get_transport(hostname))
+            sudo = args.pushy(get_transport(host))
 
             destroy_mon_r = sudo.compile(destroy_mon)
             destroy_mon_r(

--- a/ceph_deploy/new.py
+++ b/ceph_deploy/new.py
@@ -50,14 +50,7 @@ def new(args):
     mon_initial_members = []
     mon_host = []
 
-    for m in args.mon:
-        if m.count(':'):
-            (name, host) = m.split(':')
-        else:
-            name = m
-            host = m
-            if name.count('.') > 0:
-                name = name.split('.')[0]
+    for (name, host) in mon_hosts(args.mon):
         LOG.debug('Resolving host %s', host)
         ip = None
         ip = get_nonlocal_ip(host)

--- a/ceph_deploy/tests/unit/test_mon.py
+++ b/ceph_deploy/tests/unit/test_mon.py
@@ -2,6 +2,7 @@ import sys
 from mock import Mock, MagicMock, patch, call
 from ceph_deploy import mon
 from ceph_deploy.hosts.common import mon_create
+from ceph_deploy.misc import mon_hosts
 
 
 def path_exists(target_paths=None):
@@ -117,6 +118,18 @@ class TestCreateMon(object):
         result = fake_remote.call_args_list[-1][0][-1].__name__
         assert result == 'create_init_path'
 
+    def test_mon_hosts(self):
+        hosts = Mock()
+        for (name, host) in mon_hosts(('name1', 'name2.localdomain',
+                    'name3:1.2.3.6', 'name4:localhost.localdomain')):
+            hosts.get(name, host)
+
+        expected = [call.get('name1', 'name1'),
+                    call.get('name2', 'name2.localdomain'),
+                    call.get('name3', '1.2.3.6'),
+                    call.get('name4', 'localhost.localdomain')]
+        result = hosts.mock_calls
+        assert result == expected
 
 class TestIsRunning(object):
 


### PR DESCRIPTION
This patch extends the support for host:fqdn/ip notation added in bf4d18eb from new to mon create and mon destroy commands.
