### PR TITLE
add git to build-depends for vendor.py

### DIFF
--- a/ceph-deploy.spec
+++ b/ceph-deploy.spec
@@ -30,11 +30,12 @@ BuildRequires:	python-pytest
 %else
 BuildRequires:	pytest
 %endif
+BuildRequires:  git
 Requires:       python-argparse
-Requires:	pushy >= 0.5.3
+Requires:       pushy >= 0.5.3
 Requires:       python-distribute
-#Requires:	lsb-release
-#Requires:	ceph
+#Requires:      lsb-release
+#Requires:      ceph
 %if 0%{?suse_version} && 0%{?suse_version} <= 1110
 %{!?python_sitelib: %global python_sitelib %(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 %else

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Sage Weil <sage@newdream.net>
 Uploaders: Sage Weil <sage@newdream.net>
 Section: admin
 Priority: optional
-Build-Depends: debhelper (>= 7), python-setuptools
+Build-Depends: debhelper (>= 7), python-setuptools, git
 X-Python-Version: >= 2.4
 Standards-Version: 3.9.2
 Homepage: http://ceph.com/


### PR DESCRIPTION
Since vendor.py uses git to pull external dependencies such as remoto, git should be listed in BuildRequires in the spec and Build-Depends in debian/control.
