### PR TITLE
make sure to user cluster when specified

### DIFF
--- a/ceph_deploy/hosts/centos/mon/create.py
+++ b/ceph_deploy/hosts/centos/mon/create.py
@@ -18,6 +18,8 @@ def create(distro, logger, args, monitor_keyring):
         [
             service,
             'ceph',
+            '-c',
+            '/etc/ceph/{cluster}.conf'.format(cluster=args.cluster),
             'start',
             'mon.{hostname}'.format(hostname=hostname)
         ],

--- a/ceph_deploy/hosts/debian/mon/create.py
+++ b/ceph_deploy/hosts/debian/mon/create.py
@@ -34,6 +34,8 @@ def create(distro, logger, args, monitor_keyring):
             [
                 service,
                 'ceph',
+                '-c',
+                '/etc/ceph/{cluster}.conf'.format(cluster=args.cluster),
                 'start',
                 'mon.{hostname}'.format(hostname=hostname)
             ],

--- a/ceph_deploy/hosts/fedora/mon/create.py
+++ b/ceph_deploy/hosts/fedora/mon/create.py
@@ -19,6 +19,8 @@ def create(distro, logger, args, monitor_keyring):
         [
             service,
             'ceph',
+            '-c',
+            '/etc/ceph/{cluster}.conf'.format(cluster=args.cluster),
             'start',
             'mon.{hostname}'.format(hostname=hostname)
         ],

--- a/ceph_deploy/hosts/suse/mon/create.py
+++ b/ceph_deploy/hosts/suse/mon/create.py
@@ -19,6 +19,8 @@ def create(distro, logger, args, monitor_keyring):
         [
             service,
             'ceph',
+            '-c',
+            '/etc/ceph/{cluster}.conf'.format(cluster=args.cluster),
             'start',
             'mon.{hostname}'.format(hostname=hostname)
         ],


### PR DESCRIPTION
We were not honoring the fact that sometimes the user may want to specify a different cluster name.

All the monitors were assuming `ceph` as the name except for ubuntu.
