### PR TITLE
bump with fix from remoto v0.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,8 @@
 
+1.2.7
+-----
+* Ensure local calls to ceph-deploy do not attempt to ssh.
+
 1.2.6
 -----
 * Fixes a problem witha closed connection for Debian distros when creating

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if pyversion < (2, 7) or (3, 0) <= pyversion <= (3, 1):
 # Add libraries that are not part of install_requires
 #
 vendorize([
-    ('remoto', '0.0.2'),
+    ('remoto', '0.0.3'),
 ])
 
 


### PR DESCRIPTION
Pulls in remoto v0.0.3 that implements a fix to prevent ssh'ing to local machines and just uses local connections.

Fixes 6300
