### PR TITLE
[6348] ceph-deploy should use same option seperator

### DIFF
--- a/ceph_deploy/conf.py
+++ b/ceph_deploy/conf.py
@@ -13,15 +13,15 @@ class _TrimIndentFile(object):
         return line.lstrip(' \t')
 
 
-def _optionxform(s):
-    s = s.replace('_', ' ')
-    s = '_'.join(s.split())
-    return s
+class CephConf(ConfigParser.RawConfigParser):
+    def optionxform(self, s):
+        s = s.replace('_', ' ')
+        s = '_'.join(s.split())
+        return s
 
 
 def parse(fp):
-    cfg = ConfigParser.RawConfigParser()
-    cfg.optionxform = _optionxform
+    cfg = CephConf()
     ifp = _TrimIndentFile(fp)
     cfg.readfp(ifp)
     return cfg

--- a/ceph_deploy/new.py
+++ b/ceph_deploy/new.py
@@ -10,6 +10,7 @@ import socket
 
 from . import exc
 from .cliutil import priority
+from .conf import CephConf
 from .util import arg_validators
 from .misc import mon_hosts
 
@@ -42,7 +43,7 @@ def get_nonlocal_ip(host):
 
 def new(args):
     LOG.debug('Creating new cluster named %s', args.cluster)
-    cfg = ConfigParser.RawConfigParser()
+    cfg = CephConf()
     cfg.add_section('global')
 
     fsid = uuid.uuid4()

--- a/ceph_deploy/tests/test_conf.py
+++ b/ceph_deploy/tests/test_conf.py
@@ -57,3 +57,12 @@ bar__ thud   quux = baz
     cfg = conf.parse(f)
     assert cfg.get('foo', 'bar_thud_quux') == 'baz'
     assert cfg.get('foo', 'bar thud quux') == 'baz'
+
+def test_write_words_underscore():
+    cfg = conf.CephConf()
+    cfg.add_section('foo')
+    cfg.set('foo', 'bar thud quux', 'baz')
+    f = StringIO()
+    cfg.write(f)
+    f.reset()
+    assert f.readlines() == ['[foo]\n', 'bar_thud_quux = baz\n','\n']


### PR DESCRIPTION
define subclass for Ceph config files.
make new.new and conf.load use new CephConf
add test case for config writing.

Resolves 6348
