### PR TITLE
handle all errors coming from an attempt to connect

### DIFF
--- a/ceph_deploy/connection.py
+++ b/ceph_deploy/connection.py
@@ -7,8 +7,14 @@ def get_connection(hostname, logger):
     A very simple helper, meant to return a connection
     that will know about the need to use sudo.
     """
-    return Connection(
-        hostname,
-        logger=logger,
-        sudo=needs_sudo(),
-    )
+    try:
+        return Connection(
+            hostname,
+            logger=logger,
+            sudo=needs_sudo(),
+        )
+
+    except Exception as error:
+        msg = "connecting to host: %s " % hostname
+        errors = "resulted in errors: %s %s" % (error.__class__.__name__, error)
+        raise RuntimeError(msg + errors)


### PR DESCRIPTION
Please do note that the reason behind the `try Except` is because `execnet` does some weird module loading and it is impossible to catch this exceptions in the way we are including the library with ceph-deploy.

Also, we should really catch all connection problems and report them back, so I think it is entirely sensible to catch anything that may come up from the attempt at a connection.
