### PR TITLE
ceph-deploy should log command line args

### DIFF
--- a/ceph_deploy/cli.py
+++ b/ceph_deploy/cli.py
@@ -4,6 +4,7 @@ import logging
 import pushy
 import textwrap
 import sys
+from string import join
 
 import ceph_deploy
 from . import exc
@@ -143,5 +144,7 @@ def main(args=None, namespace=None):
     root_logger.addHandler(fh)
 
     sudo_pushy.patch()
-
+    
+    LOG.info("Invoked (%s): %s" %(ceph_deploy.__version__, 
+                                  join(sys.argv, " ")))
     return args.func(args)


### PR DESCRIPTION
add Log.info in cli.main to output cli args and ceph_deploy version

Fixes 6423

$ ./ceph-deploy new localhost
[ceph_deploy.cli][INFO  ] Invoked (1.2.7): ./ceph-deploy new localhost
[ceph_deploy.new][DEBUG ] Creating new cluster named ceph
