### PR TITLE
create.py: use rcceph instead of service on SUSE

### DIFF
--- a/ceph_deploy/hosts/suse/mon/create.py
+++ b/ceph_deploy/hosts/suse/mon/create.py
@@ -7,7 +7,6 @@ from ceph_deploy.connection import get_connection
 def create(distro, logger, args, monitor_keyring):
     hostname = remote_shortname(distro.sudo_conn.modules.socket)
     common.mon_create(distro, logger, args, monitor_keyring, hostname)
-    service = common.which_service(distro.sudo_conn, logger)
 
     distro.sudo_conn.close()
 
@@ -17,8 +16,7 @@ def create(distro, logger, args, monitor_keyring):
     process.run(
         rconn,
         [
-            service,
-            'ceph',
+            'rcceph',
             '-c',
             '/etc/ceph/{cluster}.conf'.format(cluster=args.cluster),
             'start',


### PR DESCRIPTION
Attempting to start a monitor node with the command:
    /sbin/service ceph -c /etc/ceph/X.conf start mon.Y
currently fails on SUSE based systems.

The failure is caused by the service binary's attempt to parse the
-c argument as its own.
Call the ceph init script directly instead to avoid this.

Signed-off-by: David Disseldorp ddiss@suse.de
