### PR TITLE
bump the version for remoto, includes fix for sudo python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if pyversion < (2, 7) or (3, 0) <= pyversion <= (3, 1):
 # Add libraries that are not part of install_requires
 #
 vendorize([
-    ('remoto', '0.0.6'),
+    ('remoto', '0.0.7'),
 ])
 
 


### PR DESCRIPTION
The bump in the version for remoto will pull the fixes needed for `sudo python` to work locally.

Fixes #6569
