### PR TITLE
ensure we can detect RedHat with whitespace too

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -66,7 +66,7 @@ def _get_distro(distro, fallback=None):
 
 def _normalized_distro_name(distro):
     distro = distro.lower()
-    if distro.startswith('redhat'):
+    if distro.startswith(('redhat', 'red hat')):
         return 'redhat'
     elif distro.startswith('suse'):
         return 'suse'

--- a/ceph_deploy/tests/unit/hosts/test_hosts.py
+++ b/ceph_deploy/tests/unit/hosts/test_hosts.py
@@ -46,6 +46,10 @@ class TestGetDistro(object):
         result = hosts._get_distro('RedHat')
         assert result.__name__.endswith('centos')
 
+    def test_get_redhat_whitespace(self):
+        result = hosts._get_distro('Red Hat Enterprise Linux')
+        assert result.__name__.endswith('centos')
+
     def test_get_uknown(self):
         with raises(exc.UnsupportedPlatform):
             hosts._get_distro('Solaris')


### PR DESCRIPTION
Ensures that we can detect 'Red Hat' as well as 'RedHat'.

Includes a test to make sure we are doing it right ™
