### PR TITLE
better path checking when attempting to write the config

### DIFF
--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -40,8 +40,15 @@ def write_conf(cluster, conf, overwrite):
             old = f.read()
             if old != conf and not overwrite:
                 raise RuntimeError(err_msg)
-    tmp_file.write(conf)
-    os.rename(tmp_file.name, path)
+        tmp_file.write(conf)
+        os.rename(tmp_file.name, path)
+        return
+    if os.path.exists('/etc/ceph'):
+        with open(path, 'w') as f:
+            f.write(conf)
+    else:
+        err_msg = '/etc/ceph/ does not exist - could not write config'
+        raise RuntimeError(err_msg)
 
 
 def write_keyring(path, key):


### PR DESCRIPTION
Will only do the tempfile dance if the config already exists and needs to be overwritten.

Otherwise it will make sure that `/etc/ceph` exists and then write the new config, else it will raise the appropriate error message about why it could not write the config file.
