### PR TITLE
fix wrong argument type for fedora installs

### DIFF
--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -38,7 +38,7 @@ def install(distro, version_kind, version, adjust_repos):
 
         process.run(
             distro.conn,
-            args=[
+            [
                 'rpm',
                 '-Uvh',
                 '--replacepkgs',
@@ -48,16 +48,16 @@ def install(distro, version_kind, version, adjust_repos):
                     url=url,
                     release=release,
                     ),
-                ]
-            )
+            ]
+        )
 
     process.run(
         distro.conn,
-        args=[
+        [
             'yum',
             '-y',
             '-q',
             'install',
             'ceph',
-            ],
-        )
+        ],
+    )


### PR DESCRIPTION
Fixes #6610. This was left over from using Pushy and requiring args to be a keyword argument.
