### PR TITLE
bump the requirement for remoto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if pyversion < (2, 7) or (3, 0) <= pyversion <= (3, 1):
 # Add libraries that are not part of install_requires
 #
 vendorize([
-    ('remoto', '0.0.10'),
+    ('remoto', '0.0.11'),
 ])
 
 


### PR DESCRIPTION
that version of `remoto` should now handle the weird `TypeError` exceptions when closing the connections
