### PR TITLE
use the key formatting when adding the key to apt too

### DIFF
--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -42,7 +42,7 @@ def install(distro, version_kind, version, adjust_repos):
             [
                 'apt-key',
                 'add',
-                'release.asc'
+                '{key}.asc'.format(key=key)
             ]
         )
 


### PR DESCRIPTION
Forgot to format the name of the key when running `apt-key add`
