### PR TITLE
Fix variable name in unsupported-platform error case.

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -37,7 +37,7 @@ def get(hostname, username=None, fallback=None):
     conn.import_module(remotes)
     distro_name, release, codename = conn.remote_module.platform_information()
     if not codename:
-        raise exc.UnsupportedPlatform(distro=distro, codename=codename)
+        raise exc.UnsupportedPlatform(distro=distro_name, codename=codename)
 
     machine_type = conn.remote_module.machine_type()
 


### PR DESCRIPTION
the rhs value distro is not defined yet, which causes an exception.
