### PR TITLE
be more lenient in correct error detection

### DIFF
--- a/ceph_deploy/util/ssh.py
+++ b/ceph_deploy/util/ssh.py
@@ -21,7 +21,7 @@ def can_connect_passwordless(hostname):
         # Check to see if we can login, disabling password prompts
         command = ['ssh', '-CT', '-o', 'BatchMode=yes', hostname]
         out, err, retval = process.check(conn, command, stop_on_error=False)
-        expected_error = 'Permission denied (publickey,password)'
+        expected_error = 'Permission denied '
         has_key_error = False
         for line in err:
             if expected_error in line:


### PR DESCRIPTION
By being more lenient we are able to detect `Permision denied` in situations where other items are added to the error message that would make this fail the detection and assume it was able to connect.
