### PR TITLE
default to emperor when installing

### DIFF
--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -212,7 +212,7 @@ def make(parser):
 
     version.set_defaults(
         func=install,
-        stable='dumpling',
+        stable='emperor',
         dev='master',
         version_kind='stable',
         adjust_repos=True,


### PR DESCRIPTION
Now that Emperor is out, ceph-deploy will default to it.
