### PR TITLE
Correctly detect openSUSE

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -77,6 +77,6 @@ def _normalized_distro_name(distro):
         return 'redhat'
     elif  distro.startswith(('scientific', 'scientific linux')):
         return 'scientific'
-    elif distro.startswith('suse'):
+    elif distro.startswith(('suse', 'opensuse')):
         return 'suse'
     return distro


### PR DESCRIPTION
ceph-deploy fails on openSUSE currently due to incorrect distro detection. It's a simple fix.
