### PR TITLE
Do not use `os.rename()`

### DIFF
--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -66,7 +66,7 @@ def write_keyring(path, key):
     """ create a keyring file """
     tmp_file = tempfile.NamedTemporaryFile(delete=False)
     tmp_file.write(key)
-    os.rename(tmp_file.name, path)
+    shutil.move(tmp_file.name, path)
 
 
 def create_mon_path(path):
@@ -150,7 +150,7 @@ def make_mon_removed_dir(path, file_name):
     except OSError, e:
         if e.errno != errno.EEXIST:
             raise
-    os.rename(path, os.path.join('/var/lib/ceph/mon-removed/', file_name))
+    shutil.move(path, os.path.join('/var/lib/ceph/mon-removed/', file_name))
 
 
 def safe_mkdir(path):


### PR DESCRIPTION
This changes all occurrences of the [`os.rename`](http://docs.python.org/3/library/os.html#os.rename) function in the remote-host helper methods (file `remotes.py`) to use [`shutil.move`](http://docs.python.org/3/library/shutil.html#shutil.move) instead.
## The issue

When `os.rename` is used in combination with `tempfile.NamedTemporaryFile`, it tries to rename the temporary file with the name of the final destination file (usually in `/var/lib/ceph` or `/etc/ceph`). However, `os.rename` requires both files to be in the same filesystem.

A lot of systems are configured to mount dedicated filesystems distinct from the root filesystem (for instance for `/tmp` and `/var`, because those are used dynamically by the system). Consequently, commands like `ceph osd prepare` fail with the message: **[Errno 18] Invalid cross-device link**
## The fix

Fortunately, Python provides the `shutil.move` function:
- if both files are on the same filesystem, it defaults to `os.rename`
- otherwise, it copies the file to the new filesystem, then deletes the old file

This has been tested and seems working. No side-effect was observed.
