### PR TITLE
warn about gpg_url when repo_url is used

### DIFF
--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -46,14 +46,14 @@ def install(args):
         repo_url = os.environ.get('CEPH_DEPLOY_REPO_URL') or args.repo_url
         gpg_url = os.environ.get('CEPH_DEPLOY_GPG_URL') or args.gpg_url
         gpg_fallback = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
-        if gpg_url is None:
+        if gpg_url is None and repo_url:
             LOG.warning('--gpg-url was not used, will fallback')
             LOG.warning('using GPG fallback: %s', gpg_fallback)
             gpg_url = gpg_fallback
 
         if repo_url:  # triggers using a custom repository
             rlogger.info('using custom repository location: %s', repo_url)
-            distro.firewall_install(
+            distro.mirror_install(
                 distro,
                 repo_url,
                 gpg_url,


### PR DESCRIPTION
After renaming the functions from `firewall_install` to `mirror_install` there was an omission that this changeset fixes.

It also addresses the problem of only warning about not using `--gpg-url` when `--repo-url` is being used.
