### PR TITLE
make sure the tmp file is closed before moving

### DIFF
--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -71,6 +71,7 @@ def write_keyring(path, key):
     """ create a keyring file """
     tmp_file = tempfile.NamedTemporaryFile(delete=False)
     tmp_file.write(key)
+    tmp_file.close()
     shutil.move(tmp_file.name, path)
 
 


### PR DESCRIPTION
this should fix all the issues we've had with temporary files being moved across file systems (the rest was taken care of by contributed pull requests)
