### PR TITLE
remove /etc/ceph

### DIFF
--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -164,7 +164,7 @@ def purge_data(args):
         process.run(
             distro.conn,
             [
-                'rm', '-rf', '--one-file-system', '--', '/etc/ceph/*',
+                'rm', '-rf', '--one-file-system', '--', '/etc/ceph/',
             ]
         )
 


### PR DESCRIPTION
We now go back to fully removing `/etc/ceph` and refuse to continue if the host has ceph installed.

Before we just used to prompt for a `y/n` to confirm and continue
