### PR TITLE
remove call to install from requirement files

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -54,5 +54,4 @@ fi
 
 test -d virtualenv || virtualenv virtualenv
 ./virtualenv/bin/python setup.py develop
-./virtualenv/bin/pip install -r requirements.txt -r requirements-dev.txt
 test -e ceph-deploy || ln -s virtualenv/bin/ceph-deploy .


### PR DESCRIPTION
These are either empty or only for testing ceph-deploy and can cause issues for teuthology because it will attempt to download/install them regardless.

These are not needed to use ceph-deploy.
