### PR TITLE
Add test to properly catch debian/sid strings from version

### DIFF
--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -6,9 +6,10 @@ import tempfile
 import platform
 
 
-def platform_information():
+def platform_information(_linux_distribution=None):
     """ detect platform information from remote host """
-    distro, release, codename = platform.linux_distribution()
+    linux_distribution = _linux_distribution or platform.linux_distribution
+    distro, release, codename = linux_distribution()
     if not codename and 'debian' in distro.lower():  # this could be an empty string in Debian
         debian_codenames = {
             '8': 'jessie',
@@ -17,6 +18,15 @@ def platform_information():
         }
         major_version = release.split('.')[0]
         codename = debian_codenames.get(major_version, '')
+
+        # In order to support newer jessie/sid or wheezy/sid strings we test this
+        # if sid is buried in the minor, we should use sid anyway.
+        if not codename and '/' in release:
+            major, minor = release.split('/')
+            if minor == 'sid':
+                codename = minor
+            else:
+                codename = major
 
     return (
         str(distro).rstrip(),

--- a/ceph_deploy/tests/test_remotes.py
+++ b/ceph_deploy/tests/test_remotes.py
@@ -1,6 +1,6 @@
 from mock import patch
 from ceph_deploy.hosts import remotes
-
+from ceph_deploy.hosts.remotes import platform_information
 
 class FakeExists(object):
 
@@ -30,3 +30,56 @@ class TestWhich(object):
             path = remotes.which('ls')
         assert path is None
 
+class TestPlatformInformation(object):
+    """ tests various inputs that remotes.platform_information handles
+
+    you can test your OS string by comparing the results with the output from:
+      python -c "import platform; print platform.linux_distribution()"
+    """
+
+    def setup(self):
+        pass
+
+    def test_handles_deb_version_num(self):
+        def fake_distro(): return ('debian', '8.4', '')
+        distro, release, codename = platform_information(fake_distro)
+        assert distro == 'debian'
+        assert release == '8.4'
+        assert codename == 'jessie'
+
+    def test_handles_deb_version_slash(self):
+        def fake_distro(): return ('debian', 'wheezy/something', '')
+        distro, release, codename = platform_information(fake_distro)
+        assert distro == 'debian'
+        assert release == 'wheezy/something'
+        assert codename == 'wheezy'
+
+    def test_handles_deb_version_slash_sid(self):
+        def fake_distro(): return ('debian', 'jessie/sid', '')
+        distro, release, codename = platform_information(fake_distro)
+        assert distro == 'debian'
+        assert release == 'jessie/sid'
+        assert codename == 'sid'
+
+    def test_handles_no_codename(self):
+        def fake_distro(): return ('SlaOS', '99.999', '')
+        distro, release, codename = platform_information(fake_distro)
+        assert distro == 'SlaOS'
+        assert release == '99.999'
+        assert codename == ''
+
+    # Normal distro strings
+    def test_hanles_centos_64(self):
+        def fake_distro(): return ('CentOS', '6.4', 'Final')
+        distro, release, codename = platform_information(fake_distro)
+        assert distro == 'CentOS'
+        assert release == '6.4'
+        assert codename == 'Final'
+
+
+    def test_handles_ubuntu_percise(self):
+        def fake_distro(): return ('Ubuntu', '12.04', 'precise')
+        distro, release, codename = platform_information(fake_distro)
+        assert distro == 'Ubuntu'
+        assert release == '12.04'
+        assert codename == 'precise'


### PR DESCRIPTION
strings for wheezy/sid and jessie/sid aren't caught by the version number
 test already implmented.

Adds test to check if codename is still empty and version contains a slash
 if so, and minor is sid, we set codename to sid. Otherwise we set codename
 to major.

Futher assessment may then made to see if we should then refuse
 jessie or sid

Signed-off-by: Andrew Woodward awoodward@mirantis.com
