### PR TITLE
catch possible requiretty errors

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -34,7 +34,11 @@ def get(hostname, username=None, fallback=None):
         username=username,
         logger=logging.getLogger(hostname)
     )
-    conn.import_module(remotes)
+    try:
+        conn.import_module(remotes)
+    except IOError as error:
+        if 'already closed' in getattr(error, 'message', ''):
+            raise RuntimeError('remote connection got closed, ensure ``requiretty`` is disabled for %s' % hostname)
     distro_name, release, codename = conn.remote_module.platform_information()
     if not codename or not _get_distro(distro_name):
         raise exc.UnsupportedPlatform(


### PR DESCRIPTION
When `requiretty` is enabled on remote hosts we should attempt to deal with that possibility and handle the error.

This does not happen when creating the SSH connection however, it only happens when a remote command is attempted that requires `sudo` so this is something that needs to be caught when attempting to retrieve the remote modules.
