### PR TITLE
distro is important object that should not be overwritern with a string

### DIFF
--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -1,5 +1,7 @@
 from ceph_deploy.util import templates, pkg_managers
 from ceph_deploy.lib.remoto import process
+import logging
+LOG = logging.getLogger(__name__)
 
 
 def install(distro, version_kind, version, adjust_repos):
@@ -11,31 +13,46 @@ def install(distro, version_kind, version, adjust_repos):
     else:
         key = 'autobuild'
 
+
+    distro_name = None
     if distro.codename == 'Mantis':
-        distro_name = 'opensuse12'
-    else:
-        distro_name = 'sles-11sp2'
+        distro_name = 'opensuse12.2'
+
+    if (distro.name == "SUSE Linux Enterprise Server") and (str(distro.release) == "11"):
+        distro_name = 'sles11'
+
+    if distro_name == None:
+        LOG.warning('Untested version of %s: assuming compatible with SUSE Linux Enterprise Server 11', distro.name)
+        distro_name = 'sles11'
+
 
     if adjust_repos:
+        # Work around code due to bug in SLE 11
+        # https://bugzilla.novell.com/show_bug.cgi?id=875170
+        protocol = "https"
+        if distro_name == 'sles11':
+            protocol = "http"
         process.run(
             distro.conn,
             [
                 'rpm',
                 '--import',
-                "https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key)
+                "{protocol}://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(
+                    key=key,
+                    protocol=protocol)
             ]
         )
 
         if version_kind == 'stable':
             url = 'http://ceph.com/rpm-{version}/{distro}/'.format(
                 version=version,
-                distro=distro,
+                distro=distro_name,
                 )
         elif version_kind == 'testing':
-            url = 'http://ceph.com/rpm-testing/{distro}/'.format(distro=distro)
+            url = 'http://ceph.com/rpm-testing/{distro}/'.format(distro=distro_name)
         elif version_kind == 'dev':
             url = 'http://gitbuilder.ceph.com/ceph-rpm-{distro}{release}-{machine}-basic/ref/{version}/'.format(
-                distro=distro,
+                distro=distro_name,
                 release=release.split(".", 1)[0],
                 machine=machine,
                 version=version,
@@ -49,7 +66,7 @@ def install(distro, version_kind, version, adjust_repos):
                 '--replacepkgs',
                 '--force',
                 '--quiet',
-                '{url}noarch/ceph-release-1-0.noarch.rpm'.format(
+                '{url}ceph-release-1-0.noarch.rpm'.format(
                     url=url,
                     ),
                 ]


### PR DESCRIPTION
Without this patch on SUSE you get:

$/tmp/ve/bin/ceph-deploy -v -v  -v --username ceph install ceph-node1
[ceph_deploy.conf][DEBUG ] found configuration file at: /home/oms101/.cephdeploy.conf
[ceph_deploy.cli][INFO  ] Invoked (1.4.0): /tmp/ve/bin/ceph-deploy -v -v -v --username ceph install ceph-node1
[ceph_deploy.install][DEBUG ] Installing stable version emperor on cluster ceph hosts ceph-node1
[ceph_deploy.install][DEBUG ] Detecting platform for host ceph-node1 ...
X11 forwarding request failed on channel 0
[ceph-node1][DEBUG ] connected to host: ceph@ceph-node1 
[ceph-node1][DEBUG ] detect platform information from remote host
[ceph-node1][DEBUG ] detect machine type
[ceph_deploy.install][INFO  ] Distro info: SUSE Linux Enterprise Server 11 x86_64
[ceph-node1][INFO  ] installing ceph on ceph-node1
Traceback (most recent call last):
  File "/tmp/ve/bin/ceph-deploy", line 9, in <module>
    load_entry_point('ceph-deploy==1.4.0', 'console_scripts', 'ceph-deploy')()
  File "/tmp/ve/lib/python2.7/site-packages/ceph_deploy-1.4.0-py2.7.egg/ceph_deploy/util/decorators.py", line 62, in newfunc
    return f(_a, *_kw)
  File "/tmp/ve/lib/python2.7/site-packages/ceph_deploy-1.4.0-py2.7.egg/ceph_deploy/cli.py", line 147, in main
    return args.func(args)
  File "/tmp/ve/lib/python2.7/site-packages/ceph_deploy-1.4.0-py2.7.egg/ceph_deploy/install.py", line 93, in install
    args.adjust_repos
  File "/tmp/ve/lib/python2.7/site-packages/ceph_deploy-1.4.0-py2.7.egg/ceph_deploy/hosts/suse/install.py", line 21, in install
    distro.conn,
AttributeError: 'str' object has no attribute 'conn'
