### PR TITLE
Remove double dashes marking end of args in 'purge' command

### DIFF
--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -36,7 +36,6 @@ def apt_remove(conn, packages, *a, **kw):
     ]
     if purge:
         cmd.append('--purge')
-    cmd.append('--')
     cmd.extend(packages)
 
     return process.run(


### PR DESCRIPTION
Without this change, the apt-get remove command executed from `ceph-deploy uninstall` or `ceph-deploy purge` will be:

```
sudo apt-get -q remove -f -y --force-yes -- ceph ceph-mds ceph-common ceph-fs-common
```

The double dashes ('--') will however prevent apt-get from correctly parsing the options, resulting in this error:

```
Command line option 'f' [from -f] is not known.
```

The same can be easily observed with a simple example:

```
$ sudo apt-get -q remove --force-yes -- vim
E: Command line option --force-yes is not understood
```

```
$ sudo apt-get -q remove --force-yes vim
Reading package lists...
Building dependency tree...
Reading state information...
[and the usual good stuff]
```

I don't see any need for the double dashes here (I hope I am not overlooking something :)).
