### PR TITLE
Add a note about running wget behind proxy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,8 @@ setup (and mirrored with all the necessary dependencies) before attempting an
 install.
 
 Another alternative is to set the ``wget`` env variables to point to the right
-hosts, for example, put following lines into ``/root/.wgetrc`` on each node (since ceph-deploy runs wget as root)::
+hosts, for example, put following lines into ``/root/.wgetrc`` on each node
+(since ceph-deploy runs wget as root)::
 
     http_proxy=http://host:port
     ftp_proxy=http://host:port


### PR DESCRIPTION
To avoid mistakes, the wget env variables should be set in
'/root/.wgetrc' since ceph-deploy will run wget as root user on each
node.

Signed-off-by: kfei kfei@kfei.net
