### PR TITLE
remove silenced install calls

### DIFF
--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -8,7 +8,6 @@ def apt(conn, packages, *a, **kw):
         'env',
         'DEBIAN_FRONTEND=noninteractive',
         'apt-get',
-        '-q',
         'install',
         '--assume-yes',
     ]
@@ -65,7 +64,6 @@ def yum(conn, packages, *a, **kw):
     cmd = [
         'yum',
         '-y',
-        '-q',
         'install',
     ]
     cmd.extend(packages)
@@ -136,7 +134,6 @@ def zypper(conn, packages, *a, **kw):
     cmd = [
         'zypper',
         '--non-interactive',
-        '--quiet',
         'install',
     ]
 


### PR DESCRIPTION
package managers will be a bit more verbose, allowing the
timer to close the connection to be pushed as long as there is output
