### PR TITLE
Add better status message when adding new monitors

### DIFF
--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -99,6 +99,9 @@ def mon_status(conn, logger, hostname, args, silent=False):
         if out['rank'] >= 0:
             logger.info('monitor: %s is running' % mon)
             return True
+        if out['rank'] == -1 and out['state']:
+            logger.info('monitor: %s is currently at the state of %s' % (mon, out['state']))
+            return True
         logger.info('monitor: %s is not running' % mon)
         return False
     except RuntimeError:


### PR DESCRIPTION
The `time.sleep(2)` in the `mon_add` method is not enough in some cases.
For example, when a low-spec slow VM acting as a monitor, it may still at
the state of 'probing' after the 2-seconds sleep. But in such cases the
`mon_status` method will just say the monitor _is not running_, it's kind of
confusion.

So maybe it would be better if provides user the current state of the
newly added monitor in the log message.

Signed-off-by: kfei kfei@kfei.net
