### PR TITLE
Fix "disk zap" sgdisk invocation

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -370,6 +370,14 @@ def disk_zap(args):
             [
                 'sgdisk',
                 '--zap-all',
+                '--',
+                disk,
+            ],
+        )
+        process.run(
+            distro.conn,
+            [
+                'sgdisk',
                 '--clear',
                 '--mbrtogpt',
                 '--',


### PR DESCRIPTION
If the metadata on the disk is truly invalid, sgdisk would fail to zero
it in one go, because --mbrtogpt apparently tried to operate on the
metadata it read before executing --zap-all.

Splitting this up into two separate invocations to first zap everything
and then clear it properly fixes this issue.
