### PR TITLE
Implement the osd destroy feature with ceph-deploy.

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -532,7 +532,7 @@ def disk_zap(args):
                 disk,
             ],
         )
-        process.run(
+        remoto.process.run(
             distro.conn,
             [
                 'sgdisk',


### PR DESCRIPTION
I think it will help to change osd configuration quickly w/o manual remove osd.

Implement the simple osd destroy feature with ceph-deploy.
It will take the osd out of the cluster, stop the osd, remove the osd and umount the osd file system.
Simply error handling with invalid hostname or error OSD-ID.

Usage: ceph-deploy osd destroy <hostname> --osd-id <OSD-ID>
