### PR TITLE
Support install on rhel7

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -20,6 +20,8 @@ def repository_url_part(distro):
     if distro.normalized_name == 'redhat':
         if distro.release.startswith('6'):
             return 'rhel6'
+        elif distro.release.startswith('7'):
+            return 'rhel7'
     return 'el6'
 
 


### PR DESCRIPTION
ceph-deploy is trying to use rhel6 rpms on rhel7.  This causing ceph-deploy install to fail with a bunch of rpm dependency issues.
