### PR TITLE
write_conf() overwrite logic fixed for python 2.6

### DIFF
--- a/ceph_deploy/conf/ceph.py
+++ b/ceph_deploy/conf/ceph.py
@@ -1,5 +1,7 @@
 import ConfigParser
 import contextlib
+from collections import OrderedDict
+from StringIO import StringIO
 
 from ceph_deploy import exc
 
@@ -35,7 +37,7 @@ class CephConf(ConfigParser.RawConfigParser):
 
 
 def parse(fp):
-    cfg = CephConf()
+    cfg = CephConf(dict_type=OrderedDict)
     ifp = _TrimIndentFile(fp)
     cfg.readfp(ifp)
     return cfg
@@ -69,20 +71,9 @@ def load_raw(args):
         )
 
 
-def write_conf(cluster, conf, overwrite):
-    """ write cluster configuration to /etc/ceph/{cluster}.conf """
-    import os
-
-    path = '/etc/ceph/{cluster}.conf'.format(cluster=cluster)
-    tmp = '{path}.{pid}.tmp'.format(path=path, pid=os.getpid())
-
-    if os.path.exists(path):
-        with file(path, 'rb') as f:
-            old = f.read()
-            if old != conf and not overwrite:
-                raise RuntimeError('config file %s exists with different content; use --overwrite-conf to overwrite' % path)
-    with file(tmp, 'w') as f:
-        f.write(conf)
-        f.flush()
-        os.fsync(f)
-    os.rename(tmp, path)
+def match(conf_data, path):
+    with file(path, 'rb') as f:
+        conf = parse(f)
+        data = StringIO()
+        conf.write(data)
+        return data.getvalue() == conf_data


### PR DESCRIPTION
Explicitly set dict_type to OrderedDict in conf.ceph.parse(): it only
became the default for RawConfigParser in Python 2.7).

Parse and re-serialize the existing config file before comparing its
contents with expected configuration to make sure that the order of
options in the file doesn't affect the comparison.

Only overwrite the file if it's contents is different and --overwrite
option was used. If the contents matches the expected configuration,
leave it untouched.

conf.ceph.write_conf() has been superceded by host.remote.write_conf()
and is not called from anywhere, so it is removed.

Closes-Bug: [#1333814](https://bugs.launchpad.net/fuel/+bug/1333814)
