### PR TITLE
add partprobing/partx calls on device when zapping

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -383,6 +383,33 @@ def disk_zap(args):
                 disk,
             ],
         )
+
+        # once all is done, call partprobe (or partx)
+        # On RHEL and CentOS distros, calling partprobe forces a reboot of the
+        # server. Since we are not resizing partitons we rely on calling
+        # partx
+        if distro.normalized_name.startswith(('centos', 'red')):
+            LOG.info('calling partx on zapped device %s', disk)
+            LOG.info('re-reading known partitions will display errors')
+            remoto.process.run(
+                distro.conn,
+                [
+                    'partx',
+                    '-a',
+                    disk,
+                ],
+            )
+
+        else:
+            LOG.debug('Calling partprobe on zapped device %s', disk)
+            remoto.process.run(
+                distro.conn,
+                [
+                    'partprobe',
+                    disk,
+                ],
+            )
+
         distro.conn.exit()
 
 


### PR DESCRIPTION
fixes a problem that would get devices in an inconsistent state after zapping.

The screenshot below shows how it picks `partx` or `partprobe` depending on the OS.

![screen shot 2014-07-03 at 2 34 24 pm](https://cloud.githubusercontent.com/assets/317847/3474189/b9011184-02e0-11e4-98df-617c519150e0.png)
