### PR TITLE
call ceph-disk zap instead of re-implementing it

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -365,26 +365,14 @@ def disk_zap(args):
             distro.codename
         )
 
-        # NOTE: this mirrors ceph-disk-prepare --zap-disk DEV
-        # zero the device
         distro.conn.remote_module.zeroing(disk)
 
+        ceph_disk_executable = system.executable_path(distro.conn, 'ceph-disk')
         remoto.process.run(
             distro.conn,
             [
-                'sgdisk',
-                '--zap-all',
-                '--',
-                disk,
-            ],
-        )
-        remoto.process.run(
-            distro.conn,
-            [
-                'sgdisk',
-                '--clear',
-                '--mbrtogpt',
-                '--',
+                ceph_disk_executable,
+                'zap',
                 disk,
             ],
         )


### PR DESCRIPTION
For historical reasons `ceph-deploy` would just try to implement the same calls as in `ceph-disk`, we should use `ceph-disk` as the source of truth and not attempt to re-implement anything.

![screen shot 2014-07-16 at 12 49 07 pm](https://cloud.githubusercontent.com/assets/317847/3602227/42cdf936-0d09-11e4-8595-fc771962e094.png)
