### PR TITLE
Set 'distro' when getting a host so that 'choose_init()' works on ubuntu

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -51,6 +51,7 @@ def get(hostname, username=None, fallback=None):
     module = _get_distro(distro_name)
     module.name = distro_name
     module.normalized_name = _normalized_distro_name(distro_name)
+    module.distro = module.normalized_name
     module.release = release
     module.codename = codename
     module.conn = conn

--- a/ceph_deploy/hosts/debian/__init__.py
+++ b/ceph_deploy/hosts/debian/__init__.py
@@ -16,6 +16,6 @@ def choose_init():
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
-    if distro == 'Ubuntu':
+    if distro.lower() == 'ubuntu':
         return 'upstart'
     return 'sysvinit'


### PR DESCRIPTION
Otherwise hosts.debian.choose_init() will always return 'sysvinit' for
ubuntu, and we won't be able to create a custom-named cluster.

Signed-off-by: Joao Eduardo Luis joao.luis@inktank.com
