### PR TITLE
check if bootstrap-osd exsits before creating the keyring file

### DIFF
--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -118,6 +118,9 @@ def write_keyring(path, key):
     tmp_file = tempfile.NamedTemporaryFile(delete=False)
     tmp_file.write(key)
     tmp_file.close()
+    keyring_dir = os.path.dirname(path)
+    if not path_exists(keyring_dir):
+        makedir(keyring_dir)
     shutil.move(tmp_file.name, path)
 
 


### PR DESCRIPTION
Signed-off-by: Dongmao Zhang dmzhang@suse.com
