### PR TITLE
Use --data-dev or --data-dir for ceph-disk parameters to avoid making di...

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -279,7 +279,7 @@ def prepare(args, cfg, activate_prepared_disk):
 
             disk_is_dir = False
             if disk[0] == "/":
-                disk_is_dir = False
+                disk_is_dir = True
             distro = hosts.get(hostname, username=args.username)
             LOG.info(
                 'Distro info: %s %s %s',

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -189,7 +189,7 @@ def catch_osd_errors(conn, logger, args):
 def detect_disk_dir(
         disk):
     path_norm = os.path.normpath(disk)
-    path_test = os.path.commonprefix([path_norm,'/dev/'])
+    path_test = os.path.commonprefix([path_norm, '/dev/'])
     if path_test == '/dev/':
         return False
     return True

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -186,6 +186,14 @@ def catch_osd_errors(conn, logger, args):
     if nearfull:
         logger.warning('OSDs are near full!')
 
+def detect_disk_dir(
+        disk):
+    path_norm = os.path.normpath(disk)
+    path_test = os.path.commonprefix([path_norm,'/dev/'])
+    if path_test == '/dev/':
+        return False
+    return True
+
 def prepare_disk_dir(
         conn,
         disk):
@@ -277,9 +285,7 @@ def prepare(args, cfg, activate_prepared_disk):
             if disk is None:
                 raise exc.NeedDiskError(hostname)
 
-            disk_is_dir = False
-            if disk[0] == "/":
-                disk_is_dir = True
+            disk_is_dir = detect_disk_dir(disk)
             distro = hosts.get(hostname, username=args.username)
             LOG.info(
                 'Distro info: %s %s %s',

--- a/ceph_deploy/tests/test_osd.py
+++ b/ceph_deploy/tests/test_osd.py
@@ -1,0 +1,19 @@
+from ceph_deploy import osd
+
+
+class TestDetectDiskDir(object):
+    def test_detect_disk_dir_negative(self):
+        assert False == osd.detect_disk_dir('/dev/sda')
+        assert False == osd.detect_disk_dir('/dev/vda')
+        assert False == osd.detect_disk_dir('/dev/hda')
+        assert False == osd.detect_disk_dir('/dev/hdz')
+        assert False == osd.detect_disk_dir('/dev/sdz')
+        assert False == osd.detect_disk_dir('///dev/sda')
+        # Note : following test fails due to os.path.normpath behavior.
+        # assert False == osd.detect_disk_dir('//dev/sda')
+
+    def test_detect_disk_dir_positive(self):
+        assert True == osd.detect_disk_dir('/mnt/foo')
+        assert True == osd.detect_disk_dir('/srv/foo')
+        assert True == osd.detect_disk_dir('/srv/foo/bar')
+        assert True == osd.detect_disk_dir('/server/foo/')


### PR DESCRIPTION
ceph-disk parameters "--data-dev" or "--data-dir" are useful to avoid making directories such as /dev/sdc by mistake when you want to use a device that does not exist.
