### PR TITLE
fallback to lowercase repo sections for Emperor

### DIFF
--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -62,7 +62,13 @@ def set_repo_priority(sections, path='/etc/yum.repos.d/ceph.repo', priority='1')
     Config.read(path)
     Config.sections()
     for section in sections:
-        Config.set(section, 'priority', priority)
+        try:
+            Config.set(section, 'priority', priority)
+        except ConfigParser.NoSectionError:
+            # Emperor versions of Ceph used all lowercase sections
+            # so lets just try again for the section that failed, maybe
+            # we are able to find it if it is lower
+            Config.set(section.lower(), 'priority', priority)
 
     with open(path, 'wb') as fout:
         Config.write(fout)


### PR DESCRIPTION
Try to fallback to all lowercase section names so that we can update priorities for Emperor

Reference issue: http://tracker.ceph.com/issues/8980
