### PR TITLE
conditionally install wget if not present

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -44,7 +44,9 @@ def install(distro, version_kind, version, adjust_repos):
     pkg_managers.yum_clean(distro.conn)
 
     # Even before EPEL, make sure we have `wget`
-    pkg_managers.yum(distro.conn, 'wget')
+    has_wget = distro.conn.remote_module.which('wget')
+    if not has_wget:
+        pkg_managers.yum(distro.conn, 'wget')
 
     # Get EPEL installed before we continue:
     if adjust_repos:


### PR DESCRIPTION
so that we are not wastefully calling yum every time

Reference issue: http://tracker.ceph.com/issues/9265

```
# new behavior does not install wget if present:

(ceph-deploy)papaya ~/tmp/foo ᓆ ssh node2 which wget
/usr/bin/wget
(ceph-deploy)papaya ~/tmp/foo ᓆ ceph-deploy install node2
[ceph_deploy.conf][DEBUG ] found configuration file at: /Users/alfredo/.cephdeploy.conf
[ceph_deploy.cli][INFO  ] Invoked (1.5.14): /Users/alfredo/.virtualenvs/ceph-deploy/bin/ceph-deploy install node2
[ceph_deploy.install][DEBUG ] Installing stable version firefly on cluster ceph hosts node2
[ceph_deploy.install][DEBUG ] Detecting platform for host node2 ...
[node2][DEBUG ] connected to host: node2
[node2][DEBUG ] detect platform information from remote host
[node2][DEBUG ] detect machine type
[ceph_deploy.install][INFO  ] Distro info: CentOS 6.4 Final
[node2][INFO  ] installing ceph on node2
[node2][INFO  ] Running command: sudo yum clean all
[node2][DEBUG ] Loaded plugins: fastestmirror, priorities
[node2][DEBUG ] Cleaning repos: Ceph Ceph-noarch base calamari ceph-source ceph_deploy epel
[node2][DEBUG ]               : extras foo updates
[node2][DEBUG ] Cleaning up Everything
[node2][DEBUG ] Cleaning up list of fastest mirrors
[node2][DEBUG ] find the location of an executable
[node2][INFO  ] adding EPEL repository
[node2][INFO  ] Running command: sudo wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
[node2][WARNIN] --2014-09-12 17:39:19--  http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
[node2][WARNIN] Resolving dl.fedoraproject.org... 209.132.181.25, 209.132.181.26, 209.132.181.27, ...
[node2][WARNIN] Connecting to dl.fedoraproject.org|209.132.181.25|:80... connected.
[node2][WARNIN] HTTP request sent, awaiting response... 200 OK
[node2][WARNIN] Length: 14540 (14K) [application/x-rpm]
...

# we now remove wget to see if that changes anything:
(ceph-deploy)papaya ~/tmp/foo ᓆ ceph-deploy pkg --remove wget node2
[ceph_deploy.conf][DEBUG ] found configuration file at: /Users/alfredo/.cephdeploy.conf
[ceph_deploy.cli][INFO  ] Invoked (1.5.14): /Users/alfredo/.virtualenvs/ceph-deploy/bin/ceph-deploy pkg --remove wget node2
[node2][DEBUG ] connected to host: node2
[node2][DEBUG ] detect platform information from remote host
[node2][DEBUG ] detect machine type
[ceph_deploy.pkg][INFO  ] Distro info: CentOS 6.4 Final
[node2][INFO  ] removing packages from node2
[node2][INFO  ] Running command: sudo yum -y -q remove wget

# and ensure it is really not there
(ceph-deploy)papaya ~/tmp/foo ᓆ ssh node2 which wget
which: no wget in (/usr/local/bin:/bin:/usr/bin)

# try installing ceph again and see if it installs wget (it doesn't)
(ceph-deploy)papaya ~/tmp/foo ᓆ ceph-deploy install node2
[ceph_deploy.conf][DEBUG ] found configuration file at: /Users/alfredo/.cephdeploy.conf
[ceph_deploy.cli][INFO  ] Invoked (1.5.14): /Users/alfredo/.virtualenvs/ceph-deploy/bin/ceph-deploy install node2
[ceph_deploy.install][DEBUG ] Installing stable version firefly on cluster ceph hosts node2
[ceph_deploy.install][DEBUG ] Detecting platform for host node2 ...
[node2][DEBUG ] connected to host: node2
[node2][DEBUG ] detect platform information from remote host
[node2][DEBUG ] detect machine type
[ceph_deploy.install][INFO  ] Distro info: CentOS 6.4 Final
[node2][INFO  ] installing ceph on node2
[node2][INFO  ] Running command: sudo yum clean all
[node2][DEBUG ] Loaded plugins: fastestmirror, priorities
[node2][DEBUG ] Cleaning repos: Ceph Ceph-noarch base calamari ceph-source ceph_deploy epel
[node2][DEBUG ]               : extras foo updates
[node2][DEBUG ] Cleaning up Everything
[node2][DEBUG ] Cleaning up list of fastest mirrors
[node2][DEBUG ] find the location of an executable
[node2][INFO  ] Running command: sudo yum -y install wget
[node2][DEBUG ] Loaded plugins: fastestmirror, priorities
[node2][DEBUG ] Determining fastest mirrors
[node2][DEBUG ]  * base: reflector.westga.edu
[node2][DEBUG ]  * epel: mirror.steadfast.net
[node2][DEBUG ]  * extras: mirror.cogentco.com
[node2][DEBUG ]  * updates: yum.tamu.edu
...
```
