### PR TITLE
ensure priorities for custom repos as well

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -143,18 +143,24 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos, extra_installs=True)
         )
 
         distro.conn.remote_module.write_yum_repo(ceph_repo_content)
+        # set the right priority
+        install_yum_priorities(distro)
+        distro.conn.remote_module.set_repo_priority(['Ceph', 'Ceph-noarch', 'ceph-source'])
+        distro.conn.logger.warning('alter.d ceph.repo priorities to contain: priority=1')
+
 
     if extra_installs:
         pkg_managers.yum(distro.conn, 'ceph')
 
 
 def repo_install(distro, reponame, baseurl, gpgkey, **kw):
+    logger = distro.conn.logger
     # Get some defaults
-    name = kw.get('name', '%s repo' % reponame)
-    enabled = kw.get('enabled', 1)
-    gpgcheck = kw.get('gpgcheck', 1)
+    name = kw.pop('name', '%s repo' % reponame)
+    enabled = kw.pop('enabled', 1)
+    gpgcheck = kw.pop('gpgcheck', 1)
     install_ceph = kw.pop('install_ceph', False)
-    proxy = kw.get('proxy')
+    proxy = kw.pop('proxy', '') # will get ignored if empty
     _type = 'repo-md'
     baseurl = baseurl.strip('/')  # Remove trailing slashes
 
@@ -179,12 +185,28 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
         _type=_type,
         gpgkey=gpgkey,
         proxy=proxy,
+        **kw
     )
 
     distro.conn.remote_module.write_yum_repo(
         repo_content,
         "%s.repo" % reponame
     )
+
+    repo_path = '/etc/yum.repos.d/{reponame}.repo'.format(reponame=reponame)
+
+    # set the right priority
+    if kw.get('priority'):
+        install_yum_priorities(distro)
+        logger.warning(
+            'ensuring that {repo_path} contains a high priority'.format(
+                repo_path=repo_path)
+        )
+
+        distro.conn.remote_module.set_repo_priority([reponame], repo_path)
+        logger.warning('altered {reponame}.repo priorities to contain: priority=1'.format(
+            reponame=reponame)
+        )
 
     # Some custom repos do not need to install ceph
     if install_ceph:


### PR DESCRIPTION
Unfortunately, custom repos where getting overridden even if they had `piority=1` because ceph-deploy was not passing that option and was not installing the plugin.

This enforces that behavior but only when the priority flag is set.

Reference ticket: http://tracker.ceph.com/issues/9645 
