### PR TITLE
Return non-zero exit status when gatherkeys fails

### DIFF
--- a/ceph_deploy/exc.py
+++ b/ceph_deploy/exc.py
@@ -95,3 +95,22 @@ class GenericError(DeployError):
 
     def __str__(self):
         return self.message
+
+
+class KeyNotFoundError(DeployError):
+    """
+    Could not find keyring file
+    """
+    def __init__(self, keyring, hosts):
+        self.keyring = keyring
+        self.hosts = hosts
+
+    def __str__(self):
+        return '{doc}: {keys}'.format(
+            doc=self.__doc__.strip(),
+            keys=', '.join(
+                [self.keyring.format(hostname=host) +
+                 " on host {hostname}".format(hostname=host)
+                 for host in self.hosts]
+            )
+        )

--- a/ceph_deploy/gatherkeys.py
+++ b/ceph_deploy/gatherkeys.py
@@ -1,7 +1,7 @@
 import os.path
 import logging
 
-from ceph_deploy import hosts
+from ceph_deploy import hosts, exc
 from ceph_deploy.cliutil import priority
 
 
@@ -14,11 +14,10 @@ def fetch_file(args, frompath, topath, _hosts):
         return True
     else:
         for hostname in _hosts:
-            LOG.debug('Checking %s for %s', hostname, frompath)
+            filepath = frompath.format(hostname=hostname)
+            LOG.debug('Checking %s for %s', hostname, filepath)
             distro = hosts.get(hostname, username=args.username)
-            key = distro.conn.remote_module.get_file(
-                frompath.format(hostname=hostname)
-            )
+            key = distro.conn.remote_module.get_file(filepath)
 
             if key is not None:
                 LOG.debug('Got %s key from %s.', topath, hostname)
@@ -26,51 +25,51 @@ def fetch_file(args, frompath, topath, _hosts):
                     f.write(key)
                     return True
             distro.conn.exit()
-    LOG.warning('Unable to find %s on %s', frompath, _hosts)
+            LOG.warning('Unable to find %s on %s', filepath, hostname)
     return False
 
 
 def gatherkeys(args):
-    ret = 0
-
     # client.admin
+    keyring = '/etc/ceph/{cluster}.client.admin.keyring'.format(
+        cluster=args.cluster)
     r = fetch_file(
         args=args,
-        frompath='/etc/ceph/{cluster}.client.admin.keyring'.format(
-            cluster=args.cluster),
+        frompath=keyring,
         topath='{cluster}.client.admin.keyring'.format(
             cluster=args.cluster),
         _hosts=args.mon,
         )
     if not r:
-        ret = 1
+        raise exc.KeyNotFoundError(keyring, args.mon)
 
     # mon.
+    keyring = '/var/lib/ceph/mon/{cluster}-{{hostname}}/keyring'.format(
+        cluster=args.cluster)
     r = fetch_file(
         args=args,
-        frompath='/var/lib/ceph/mon/%s-{hostname}/keyring' % args.cluster,
+        frompath=keyring,
         topath='{cluster}.mon.keyring'.format(cluster=args.cluster),
         _hosts=args.mon,
         )
     if not r:
-        ret = 1
+        raise exc.KeyNotFoundError(keyring, args.mon)
 
     # bootstrap
     for what in ['osd', 'mds']:
+        keyring = '/var/lib/ceph/bootstrap-{what}/{cluster}.keyring'.format(
+            what=what,
+            cluster=args.cluster)
         r = fetch_file(
             args=args,
-            frompath='/var/lib/ceph/bootstrap-{what}/{cluster}.keyring'.format(
-                cluster=args.cluster,
-                what=what),
+            frompath=keyring,
             topath='{cluster}.bootstrap-{what}.keyring'.format(
                 cluster=args.cluster,
                 what=what),
             _hosts=args.mon,
             )
         if not r:
-            ret = 1
-
-    return ret
+            raise exc.KeyNotFoundError(keyring, args.mon)
 
 
 @priority(40)


### PR DESCRIPTION
http://tracker.ceph.com/issues/10043

Raise an exception that causes an exit code of 1 to be returned when a call to gatherkeys fails.

I have one concern with the way I implemented this -- the command itself seems to be able to handle being given a list of monitors to check.  However, with this change, the command will abort/exit as soon as a single keyring file is not found.  It's unclear to me whether that's the way it should be.  I had explained my reasoning in the tracker, but now I'm not so sure.

I could instead have the exception be thrown at the very end only if the keys couldn't be found anywhere.  I took the approach I did because i thought it would be an error if any monitor did not have any the required keyring files.
