### PR TITLE
Fix string compare for distro during EPEL install

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -116,7 +116,7 @@ def install_epel(distro):
     CentOS and Scientific need the EPEL repo, otherwise Ceph cannot be
     installed.
     """
-    if distro.name.lower() in ['centos', 'scientific']:
+    if distro.normalized_name in ['centos', 'scientific']:
         distro.conn.logger.info('adding EPEL repository')
         pkg_managers.yum(distro.conn, 'epel-release')
 


### PR DESCRIPTION
Use distro.normalized_name instead of
distro.name.lower

Signed-off-by: Travis Rhoden trhoden@redhat.com
