### PR TITLE
rpmlint fixes

### DIFF
--- a/ceph-deploy.spec
+++ b/ceph-deploy.spec
@@ -10,25 +10,25 @@
 #################################################################################
 # common
 #################################################################################
-Name:		ceph-deploy
-Version:       1.5.21
-Release: 	0
-Summary: 	Admin and deploy tool for Ceph
-License: 	MIT
-Group:   	System/Filesystems
-URL:     	http://ceph.com/
-Source0: 	%{name}-%{version}.tar.bz2
+Name:           ceph-deploy
+Version:        1.5.21
+Release:        0
+Summary:        Admin and deploy tool for Ceph
+License:        MIT
+Group:          System/Filesystems
+URL:            http://ceph.com/
+Source0:        %{name}-%{version}.tar.bz2
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python-devel
 BuildRequires:  python-distribute
-BuildRequires:	python-setuptools
-BuildRequires:	python-virtualenv
+BuildRequires:  python-setuptools
+BuildRequires:  python-virtualenv
 BuildRequires:  python-mock
 BuildRequires:  python-tox
 %if 0%{?suse_version}
-BuildRequires:	python-pytest
+BuildRequires:  python-pytest
 %else
-BuildRequires:	pytest
+BuildRequires:  pytest
 %endif
 BuildRequires:  git
 Requires:       python-argparse
@@ -49,8 +49,8 @@ BuildArch:      noarch
 %endif
 
 %if 0%{?rhel}
-BuildRequires: 	python >= %{pyver}
-Requires: 	python >= %{pyver}
+BuildRequires:  python >= %{pyver}
+Requires:       python >= %{pyver}
 %endif
 
 %description

--- a/ceph-deploy.spec
+++ b/ceph-deploy.spec
@@ -57,7 +57,7 @@ Requires:       python >= %{pyver}
 An easy to use admin tool for deploy ceph storage clusters.
 
 %prep
-#%setup -q -n %{name}
+#%%setup -q -n %%{name}
 %setup -q
 
 %build


### PR DESCRIPTION
This pull request fixes two types of rpmlint warnings in the ceph-deploy RPM packaging.

The first commit changes the tabs to spaces in the `ceph-deploy.spec` file.

The second commit quotes the RPM macros in the comments of `ceph-deploy.spec`.