### PR TITLE
Enable check_obsoletes in Fedora

### DIFF
--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -15,6 +15,8 @@ def install(distro, version_kind, version, adjust_repos):
 
     if adjust_repos:
         install_yum_priorities(distro)
+        distro.conn.remote_module.enable_yum_priority_obsoletes()
+        logger.warning('check_obsoletes has been enabled for Yum priorities plugin')
 
         if version_kind != 'dev':
             remoto.process.run(

--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -313,6 +313,15 @@ def zeroing(dev):
         f.write(size*'\0')
 
 
+def enable_yum_priority_obsoletes(path="/etc/yum/pluginconf.d/priorities.conf"):
+    """Configure Yum priorities to include obsoletes"""
+    config = ConfigParser.ConfigParser()
+    config.read(path)
+    config.set('main', 'check_obsoletes', '1')
+    with open(path, 'wb') as fout:
+        config.write(fout)
+
+
 # remoto magic, needed to execute these functions remotely
 if __name__ == '__channelexec__':
     for item in channel:  # noqa

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -32,6 +32,24 @@ displayed, similar to::
     are not going to be uninstalled. For example librbd1 and librados which
     qemu-kvm depends on, and removing it would cause issues for qemu-kvm.
 
+Distribution Notes
+------------------
+
+RPMs
+^^^^
+
+On RPM-based distributions, ``yum-plugin-priorities`` is installed to make sure
+that upstream ceph.com repos have a higher priority than distro repos.
+
+Fedora
+^^^^^^
+
+The Fedora distribution maintains packages for Ceph in their own repos, independent
+of the upstream repos on ceph.com.  The packages are structured differently than
+the upstream packages, and can cause dependency resolution errors despite the use
+of the Yum priorities plugin.  To resolve this, ``ceph-deploy`` enables the
+``check_obsoletes`` flag for the Yum priorities plugin.
+
 Specific Releases
 -----------------
 By default the *latest* release is assumed. This value changes when


### PR DESCRIPTION
Since Fedora ships downstream RPMs that obsolete
python-ceph, those RPMs will be pulled in to resolve
dependencies instead of those hosted by ceph.com, leading
to package errors.

To prevent this, enable check_obsoletes in the Yum
priorities plugin.

Fixes: 10476

Signed-off-by: Travis Rhoden <trhoden@redhat.com>