### PR TITLE
ceph-deploy.spec: remove %{pyver} references

### DIFF
--- a/ceph-deploy.spec
+++ b/ceph-deploy.spec
@@ -48,11 +48,6 @@ BuildArch:      noarch
 %py_requires
 %endif
 
-%if 0%{?rhel}
-BuildRequires:  python >= %{pyver}
-Requires:       python >= %{pyver}
-%endif
-
 %description
 An easy to use admin tool for deploy ceph storage clusters.
 


### PR DESCRIPTION
The `%{pyver}` RPM macro is not present on Red Hat-based systems. It was removed for SUSE as a part of commit 83070c14f1682e3b6eb7f45f43ba6afda6f026a4. This pull request removes it for RHEL also.

This fixes a problem where `rpm -qp --requires ceph-deploy-1.5.21-0.noarch.rpm` would show that the binary RPM literally required `python >= %{pyver}`, since RPM did not interpolate the macro to any value.