### PR TITLE
RHEL packaging split support

### DIFF
--- a/ceph_deploy/hosts/rhel/__init__.py
+++ b/ceph_deploy/hosts/rhel/__init__.py
@@ -1,0 +1,19 @@
+import mon  # noqa
+import pkg  # noqa
+from install import install, mirror_install, repo_install  # noqa
+from uninstall import uninstall  # noqa
+
+# Allow to set some information about this distro
+#
+
+distro = None
+release = None
+codename = None
+
+def choose_init():
+    """
+    Select a init system
+
+    Returns the name of a init system (upstart, sysvinit ...).
+    """
+    return 'sysvinit'

--- a/ceph_deploy/hosts/rhel/install.py
+++ b/ceph_deploy/hosts/rhel/install.py
@@ -1,0 +1,78 @@
+from ceph_deploy.util import pkg_managers, templates
+from ceph_deploy.lib import remoto
+
+
+def install(distro, version_kind, version, adjust_repos):
+    pkg_managers.yum_clean(distro.conn)
+    pkg_managers.yum(distro.conn, ['ceph', 'ceph-mon', 'ceph-osd'])
+
+
+def mirror_install(distro, repo_url, gpg_url, adjust_repos, extra_installs=True):
+    repo_url = repo_url.strip('/')  # Remove trailing slashes
+    gpg_url_path = gpg_url.split('file://')[-1]  # Remove file if present
+
+    pkg_managers.yum_clean(distro.conn)
+
+    if adjust_repos:
+        remoto.process.run(
+            distro.conn,
+            [
+                'rpm',
+                '--import',
+                gpg_url_path,
+            ]
+        )
+
+        ceph_repo_content = templates.ceph_repo.format(
+            repo_url=repo_url,
+            gpg_url=gpg_url
+        )
+
+        distro.conn.remote_module.write_yum_repo(ceph_repo_content)
+
+    if extra_installs:
+        pkg_managers.yum(distro.conn, ['ceph', 'ceph-mon', 'ceph-osd'])
+
+
+def repo_install(distro, reponame, baseurl, gpgkey, **kw):
+    # Get some defaults
+    name = kw.pop('name', '%s repo' % reponame)
+    enabled = kw.pop('enabled', 1)
+    gpgcheck = kw.pop('gpgcheck', 1)
+    install_ceph = kw.pop('install_ceph', False)
+    proxy = kw.pop('proxy', '') # will get ignored if empty
+    _type = 'repo-md'
+    baseurl = baseurl.strip('/')  # Remove trailing slashes
+
+    pkg_managers.yum_clean(distro.conn)
+
+    if gpgkey:
+        remoto.process.run(
+            distro.conn,
+            [
+                'rpm',
+                '--import',
+                gpgkey,
+            ]
+        )
+
+    repo_content = templates.custom_repo(
+        reponame=reponame,
+        name=name,
+        baseurl=baseurl,
+        enabled=enabled,
+        gpgcheck=gpgcheck,
+        _type=_type,
+        gpgkey=gpgkey,
+        proxy=proxy,
+        **kw
+    )
+
+    distro.conn.remote_module.write_yum_repo(
+        repo_content,
+        "%s.repo" % reponame
+    )
+
+    # Some custom repos do not need to install ceph
+    if install_ceph:
+        pkg_managers.yum(distro.conn, ['ceph', 'ceph-mon', 'ceph-osd'])

--- a/ceph_deploy/hosts/rhel/mon/__init__.py
+++ b/ceph_deploy/hosts/rhel/mon/__init__.py
@@ -1,0 +1,2 @@
+from ceph_deploy.hosts.common import mon_add as add  # noqa
+from create import create  # noqa

--- a/ceph_deploy/hosts/rhel/mon/create.py
+++ b/ceph_deploy/hosts/rhel/mon/create.py
@@ -1,0 +1,24 @@
+from ceph_deploy.hosts import common
+from ceph_deploy.util import system
+from ceph_deploy.lib import remoto
+
+
+def create(distro, args, monitor_keyring):
+    hostname = distro.conn.remote_module.shortname()
+    common.mon_create(distro, args, monitor_keyring, hostname)
+    service = distro.conn.remote_module.which_service()
+
+    remoto.process.run(
+        distro.conn,
+        [
+            service,
+            'ceph',
+            '-c',
+            '/etc/ceph/{cluster}.conf'.format(cluster=args.cluster),
+            'start',
+            'mon.{hostname}'.format(hostname=hostname)
+        ],
+        timeout=7,
+    )
+
+    system.enable_service(distro.conn)

--- a/ceph_deploy/hosts/rhel/pkg.py
+++ b/ceph_deploy/hosts/rhel/pkg.py
@@ -1,0 +1,15 @@
+from ceph_deploy.util import pkg_managers
+
+
+def install(distro, packages):
+    return pkg_managers.yum(
+        distro.conn,
+        packages
+    )
+
+
+def remove(distro, packages):
+    return pkg_managers.yum_remove(
+        distro.conn,
+        packages
+    )

--- a/ceph_deploy/hosts/rhel/uninstall.py
+++ b/ceph_deploy/hosts/rhel/uninstall.py
@@ -1,0 +1,17 @@
+from ceph_deploy.util import pkg_managers
+
+
+def uninstall(conn, purge=False):
+    packages = [
+        'ceph',
+        'ceph-common',
+        'ceph-mon',
+        'ceph-osd'
+        ]
+
+    pkg_managers.yum_remove(
+        conn,
+        packages,
+    )
+
+    pkg_managers.yum_clean(conn)

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -37,7 +37,10 @@ def install(args):
 
     for hostname in args.host:
         LOG.debug('Detecting platform for host %s ...', hostname)
-        distro = hosts.get(hostname, username=args.username)
+        distro = hosts.get(
+            hostname,
+            username=args.username,
+            use_rhceph=bool(getattr(args, 'use_rhceph', False)))
         LOG.info(
             'Distro info: %s %s %s',
             distro.name,
@@ -214,7 +217,10 @@ def uninstall(args):
     for hostname in args.host:
         LOG.debug('Detecting platform for host %s ...', hostname)
 
-        distro = hosts.get(hostname, username=args.username)
+        distro = hosts.get(
+            hostname,
+            username=args.username,
+            use_rhceph=bool(getattr(args, 'use_rhceph', False)))
         LOG.info('Distro info: %s %s %s', distro.name, distro.release, distro.codename)
         rlogger = logging.getLogger(hostname)
         rlogger.info('uninstalling ceph on %s' % hostname)
@@ -235,7 +241,10 @@ def purge(args):
     for hostname in args.host:
         LOG.debug('Detecting platform for host %s ...', hostname)
 
-        distro = hosts.get(hostname, username=args.username)
+        distro = hosts.get(
+            hostname,
+            username=args.username,
+            use_rhceph=bool(getattr(args, 'use_rhceph', False)))
         LOG.info('Distro info: %s %s %s', distro.name, distro.release, distro.codename)
         rlogger = logging.getLogger(hostname)
         rlogger.info('purging host ... %s' % hostname)


### PR DESCRIPTION
This adds a RHEL host module that is meant to deal with the details of installing RHCeph on RHEL machines.  The RHEL module starts from a copy of the centos module, and removes the pieces around Yum priorities and EPEL.

It then always installs the two new packages ceph-mon and ceph-osd.

ceph-deploy will need a bit more work in order to correctly install ceph-mon and ceph-osd only on the needed hosts.  I think that is a bigger revamp that can wait.

The centos host module will still be used on RHEL machines when installing a community version of ceph.  The trigger for whether or not the rhel or centos module is used on a rhel machine is the flag "use_rhceph=true" in the global or install section of cephdeploy.conf.

I tested three scenarios:

A RHEL7 admin and monitor node.  Installed dev version of ceph-deploy on admin node, and enabled "use_rhceph = true" in /root/.cephdeploy.conf after running "ceph-deploy new [mon node]".  On that mon node, I had pre-installed .repo files to point to an internal RH repo that contains the dev versions of RH Ceph. THen, running "ceph-deploy install --no-adjust-repos [mon node]" correctly installed ceph, ceph-mon, and ceph-osd packages and dependencies.  EPEL and yum priorities were not installed.

I cleaned that setup, and tried the same thing without "use_rhceph = true" set in .cephdeploy.conf.  After enabling the server-optional channel, I was able to install the community giant version of Ceph.  So that looks good still.  It only installed the ceph package, thereby using the centos host module, not the RHEL host module.

I then did a CentOS7 setup, and that worked normally as well -- successfully installing the community version as it is currently packaged.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1192579