### PR TITLE
Enable check_obsoletes for CentOS and RHEL

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -47,6 +47,8 @@ def install(distro, version_kind, version, adjust_repos):
     if adjust_repos:
         install_epel(distro)
         install_yum_priorities(distro)
+        distro.conn.remote_module.enable_yum_priority_obsoletes()
+        logger.warning('check_obsoletes has been enabled for Yum priorities plugin')
     if version_kind in ['stable', 'testing']:
         key = 'release'
     else:


### PR DESCRIPTION
We previously enabled this Yum plugin config flag for Fedora, but
recent changes in the EPEL packaging make it necessary for CentOS
and RHEL (when using upstream packages) as well.

Signed-off-by: Travis Rhoden <trhoden@redhat.com>