### PR TITLE
rhel repo support

### DIFF
--- a/ceph_deploy/cli.py
+++ b/ceph_deploy/cli.py
@@ -93,6 +93,8 @@ def get_parser():
         if not os.environ.get('CEPH_DEPLOY_TEST'):
             p.set_defaults(cd_conf=ceph_deploy.conf.cephdeploy.load())
 
+        # flag if the default release is being used
+        p.set_defaults(default_release=False)
         fn(p)
     parser.set_defaults(
         # we want to hold on to this, for later

--- a/ceph_deploy/hosts/rhel/__init__.py
+++ b/ceph_deploy/hosts/rhel/__init__.py
@@ -1,0 +1,19 @@
+import mon  # noqa
+import pkg  # noqa
+from install import install, mirror_install, repo_install  # noqa
+from uninstall import uninstall  # noqa
+
+# Allow to set some information about this distro
+#
+
+distro = None
+release = None
+codename = None
+
+def choose_init():
+    """
+    Select a init system
+
+    Returns the name of a init system (upstart, sysvinit ...).
+    """
+    return 'sysvinit'

--- a/ceph_deploy/hosts/rhel/install.py
+++ b/ceph_deploy/hosts/rhel/install.py
@@ -1,0 +1,78 @@
+from ceph_deploy.util import pkg_managers, templates
+from ceph_deploy.lib import remoto
+
+
+def install(distro, version_kind, version, adjust_repos):
+    pkg_managers.yum_clean(distro.conn)
+    pkg_managers.yum(distro.conn, ['ceph', 'ceph-mon', 'ceph-osd'])
+
+
+def mirror_install(distro, repo_url, gpg_url, adjust_repos, extra_installs=True):
+    repo_url = repo_url.strip('/')  # Remove trailing slashes
+    gpg_url_path = gpg_url.split('file://')[-1]  # Remove file if present
+
+    pkg_managers.yum_clean(distro.conn)
+
+    if adjust_repos:
+        remoto.process.run(
+            distro.conn,
+            [
+                'rpm',
+                '--import',
+                gpg_url_path,
+            ]
+        )
+
+        ceph_repo_content = templates.ceph_repo.format(
+            repo_url=repo_url,
+            gpg_url=gpg_url
+        )
+
+        distro.conn.remote_module.write_yum_repo(ceph_repo_content)
+
+    if extra_installs:
+        pkg_managers.yum(distro.conn, ['ceph', 'ceph-mon', 'ceph-osd'])
+
+
+def repo_install(distro, reponame, baseurl, gpgkey, **kw):
+    # Get some defaults
+    name = kw.pop('name', '%s repo' % reponame)
+    enabled = kw.pop('enabled', 1)
+    gpgcheck = kw.pop('gpgcheck', 1)
+    install_ceph = kw.pop('install_ceph', False)
+    proxy = kw.pop('proxy', '') # will get ignored if empty
+    _type = 'repo-md'
+    baseurl = baseurl.strip('/')  # Remove trailing slashes
+
+    pkg_managers.yum_clean(distro.conn)
+
+    if gpgkey:
+        remoto.process.run(
+            distro.conn,
+            [
+                'rpm',
+                '--import',
+                gpgkey,
+            ]
+        )
+
+    repo_content = templates.custom_repo(
+        reponame=reponame,
+        name=name,
+        baseurl=baseurl,
+        enabled=enabled,
+        gpgcheck=gpgcheck,
+        _type=_type,
+        gpgkey=gpgkey,
+        proxy=proxy,
+        **kw
+    )
+
+    distro.conn.remote_module.write_yum_repo(
+        repo_content,
+        "%s.repo" % reponame
+    )
+
+    # Some custom repos do not need to install ceph
+    if install_ceph:
+        pkg_managers.yum(distro.conn, ['ceph', 'ceph-mon', 'ceph-osd'])

--- a/ceph_deploy/hosts/rhel/mon/__init__.py
+++ b/ceph_deploy/hosts/rhel/mon/__init__.py
@@ -1,0 +1,2 @@
+from ceph_deploy.hosts.common import mon_add as add  # noqa
+from create import create  # noqa

--- a/ceph_deploy/hosts/rhel/mon/create.py
+++ b/ceph_deploy/hosts/rhel/mon/create.py
@@ -1,0 +1,24 @@
+from ceph_deploy.hosts import common
+from ceph_deploy.util import system
+from ceph_deploy.lib import remoto
+
+
+def create(distro, args, monitor_keyring):
+    hostname = distro.conn.remote_module.shortname()
+    common.mon_create(distro, args, monitor_keyring, hostname)
+    service = distro.conn.remote_module.which_service()
+
+    remoto.process.run(
+        distro.conn,
+        [
+            service,
+            'ceph',
+            '-c',
+            '/etc/ceph/{cluster}.conf'.format(cluster=args.cluster),
+            'start',
+            'mon.{hostname}'.format(hostname=hostname)
+        ],
+        timeout=7,
+    )
+
+    system.enable_service(distro.conn)

--- a/ceph_deploy/hosts/rhel/pkg.py
+++ b/ceph_deploy/hosts/rhel/pkg.py
@@ -1,0 +1,15 @@
+from ceph_deploy.util import pkg_managers
+
+
+def install(distro, packages):
+    return pkg_managers.yum(
+        distro.conn,
+        packages
+    )
+
+
+def remove(distro, packages):
+    return pkg_managers.yum_remove(
+        distro.conn,
+        packages
+    )

--- a/ceph_deploy/hosts/rhel/uninstall.py
+++ b/ceph_deploy/hosts/rhel/uninstall.py
@@ -1,0 +1,17 @@
+from ceph_deploy.util import pkg_managers
+
+
+def uninstall(conn, purge=False):
+    packages = [
+        'ceph',
+        'ceph-common',
+        'ceph-mon',
+        'ceph-osd'
+        ]
+
+    pkg_managers.yum_remove(
+        conn,
+        packages,
+    )
+
+    pkg_managers.yum_clean(conn)

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -58,7 +58,8 @@ def install(args):
             # upstream. If default_release is True, it means that the user is
             # trying to install on a RHEL machine and should expect to get RHEL
             # packages. Otherwise, it will need to specify either a specific
-            # version, or repo, or a development branch.
+            # version, or repo, or a development branch. Other distro users should
+            # not see any differences.
             use_rhceph=args.default_release,
             )
         LOG.info(

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -37,7 +37,10 @@ def install(args):
 
     for hostname in args.host:
         LOG.debug('Detecting platform for host %s ...', hostname)
-        distro = hosts.get(hostname, username=args.username)
+        distro = hosts.get(
+            hostname,
+            username=args.username,
+            use_rhceph=bool(getattr(args, 'use_rhceph', False)))
         LOG.info(
             'Distro info: %s %s %s',
             distro.name,
@@ -214,7 +217,10 @@ def uninstall(args):
     for hostname in args.host:
         LOG.debug('Detecting platform for host %s ...', hostname)
 
-        distro = hosts.get(hostname, username=args.username)
+        distro = hosts.get(
+            hostname,
+            username=args.username,
+            use_rhceph=bool(getattr(args, 'use_rhceph', False)))
         LOG.info('Distro info: %s %s %s', distro.name, distro.release, distro.codename)
         rlogger = logging.getLogger(hostname)
         rlogger.info('uninstalling ceph on %s' % hostname)
@@ -235,7 +241,10 @@ def purge(args):
     for hostname in args.host:
         LOG.debug('Detecting platform for host %s ...', hostname)
 
-        distro = hosts.get(hostname, username=args.username)
+        distro = hosts.get(
+            hostname,
+            username=args.username,
+            use_rhceph=bool(getattr(args, 'use_rhceph', False)))
         LOG.info('Distro info: %s %s %s', distro.name, distro.release, distro.codename)
         rlogger = logging.getLogger(hostname)
         rlogger.info('purging host ... %s' % hostname)

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -240,7 +240,7 @@ def uninstall(args):
         distro = hosts.get(
             hostname,
             username=args.username,
-            use_rhceph=bool(getattr(args, 'use_rhceph', False)))
+            use_rhceph=True)
         LOG.info('Distro info: %s %s %s', distro.name, distro.release, distro.codename)
         rlogger = logging.getLogger(hostname)
         rlogger.info('uninstalling ceph on %s' % hostname)
@@ -264,7 +264,8 @@ def purge(args):
         distro = hosts.get(
             hostname,
             username=args.username,
-            use_rhceph=bool(getattr(args, 'use_rhceph', False)))
+            use_rhceph=True
+        )
         LOG.info('Distro info: %s %s %s', distro.name, distro.release, distro.codename)
         rlogger = logging.getLogger(hostname)
         rlogger.info('purging host ... %s' % hostname)

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -54,7 +54,13 @@ def install(args):
         distro = hosts.get(
             hostname,
             username=args.username,
-            use_rhceph=bool(getattr(args, 'use_rhceph', False)))
+            # XXX this should get removed once ceph packages are split for
+            # upstream. If default_release is True, it means that the user is
+            # trying to install on a RHEL machine and should expect to get RHEL
+            # packages. Otherwise, it will need to specify either a specific
+            # version, or repo, or a development branch.
+            use_rhceph=args.default_release,
+            )
         LOG.info(
             'Distro info: %s %s %s',
             distro.name,

--- a/ceph_deploy/tests/test_install.py
+++ b/ceph_deploy/tests/test_install.py
@@ -9,6 +9,7 @@ class TestSanitizeArgs(object):
         self.args = Mock()
         # set the default behavior we set in cli.py
         self.args.default_release = False
+        self.args.stable = None
 
     def test_args_release_not_specified(self):
         self.args.release = None
@@ -20,3 +21,18 @@ class TestSanitizeArgs(object):
         # change that. Future improvement: make the default release a
         # variable in `ceph_deploy/__init__.py`
         assert result.default_release is True
+
+    def test_args_release_is_specified(self):
+        self.args.release = 'dumpling'
+        result = install.sanitize_args(self.args)
+        assert result.default_release is False
+
+    def test_args_release_stable_is_used(self):
+        self.args.stable = 'dumpling'
+        result = install.sanitize_args(self.args)
+        assert result.release == 'dumpling'
+
+    def test_args_stable_is_not_used(self):
+        self.args.release = 'dumpling'
+        result = install.sanitize_args(self.args)
+        assert result.stable is None

--- a/ceph_deploy/tests/test_install.py
+++ b/ceph_deploy/tests/test_install.py
@@ -1,0 +1,22 @@
+from mock import Mock
+
+from ceph_deploy import install
+
+
+class TestSanitizeArgs(object):
+
+    def setup(self):
+        self.args = Mock()
+        # set the default behavior we set in cli.py
+        self.args.default_release = False
+
+    def test_args_release_not_specified(self):
+        self.args.release = None
+        result = install.sanitize_args(self.args)
+        # XXX
+        # we should get `args.release` to be the latest release
+        # but we don't want to be updating this test every single
+        # time there is a new default value, and we can't programatically
+        # change that. Future improvement: make the default release a
+        # variable in `ceph_deploy/__init__.py`
+        assert result.default_release is True


### PR DESCRIPTION
this adds a bit on top of @trhoden work by adding a namespace attribute that tells if a user explicitly asked for a ceph release or not.

This "check for a default and change otherwise" logic will enable us to enforce a behavior where a user in a RHEL system to use the RHEL packages *by default* unless it is specifying otherwise.

Some of the changes are temporary, since this is just to address the immediate need to support split Ceph packages.