### PR TITLE
Detect RHEL/RHCEPH for 'install --repo'

### DIFF
--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -213,7 +213,17 @@ def install_repo(args):
 
     for hostname in args.host:
         LOG.debug('Detecting platform for host %s ...', hostname)
-        distro = hosts.get(hostname, username=args.username)
+        distro = hosts.get(
+            hostname,
+            username=args.username,
+            # XXX this should get removed once ceph packages are split for
+            # upstream. If default_release is True, it means that the user is
+            # trying to install on a RHEL machine and should expect to get RHEL
+            # packages. Otherwise, it will need to specify either a specific
+            # version, or repo, or a development branch. Other distro users should
+            # not see any differences.
+            use_rhceph=args.default_release,
+        )
         rlogger = logging.getLogger(hostname)
 
         LOG.info(


### PR DESCRIPTION
The output from running "ice_setup" instructs users to run "ceph-deploy install --repo {hosts}".

That command would fail because it was not loading the RHEL host module when it needed to (it used the centos module).