### PR TITLE
Try to remove also ceph-common on Fedora.

### DIFF
--- a/ceph_deploy/hosts/fedora/uninstall.py
+++ b/ceph_deploy/hosts/fedora/uninstall.py
@@ -4,6 +4,7 @@ from ceph_deploy.util import pkg_managers
 def uninstall(conn, purge=False):
     packages = [
         'ceph',
+        'ceph-common',
         ]
 
     pkg_managers.yum_remove(


### PR DESCRIPTION
Quick workaround but at least it allows purge and purgedata to work
on Fedora 21.

See http://tracker.ceph.com/issues/10928