### PR TITLE
ceph-deploy doc additions and rework

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,8 +1,11 @@
 Changelog
 =========
 
+1.5
+---
+
 1.5.22
-------
+^^^^^^
 09-Mar-2015
 
 * Enable ``check_obsoletes`` in Yum priorities plugin when deploying
@@ -11,7 +14,7 @@ Changelog
 * Uninstall ``ceph-common`` on Fedora
 
 1.5.21
-------
+^^^^^^
 10-Dec-2014
 
 * Fix distro detection for CentOS and Scientific Linux, which was
@@ -21,34 +24,34 @@ Changelog
   keys were not found.
 
 1.5.20
-------
+^^^^^^
 13-Nov-2014
 
 * log stderr and stdout in the same order as they happen remotely.
 
 1.5.19
-------
+^^^^^^
 29-Oct-2014
 
 * Create temporary ceph.conf files in ``/etc/ceph`` to avoid issues with
   SELinux.
 
 1.5.18
-------
+^^^^^^
 09-Oct-2014
 
 * Fix issue for enabling the OSD service in el-like distros.
 * Create a monitor keyring if it doesn't exist.
 
 1.5.17
-------
+^^^^^^
 06-Oct-2014
 
 * Do not ask twice for passwords when calling ``new``.
 * Ensure priorities are installed and enforced for custom repositories.
 
 1.5.16
-------
+^^^^^^
 30-Sep-2014
 
 * Enable services on ``el`` distros when deploying Ceph daemons.
@@ -58,20 +61,20 @@ Changelog
   detection.
 
 1.5.15
-------
+^^^^^^
 12-Sep-2014
 
 * If ``wget`` is installed don't try to install it regardless.
 
 1.5.14
-------
+^^^^^^
 09-Sep-2014
 
 * Do not override environment variables on remote hosts, preserve them and
   extend the ``$PATH`` if not explicitly told not to.
 
 1.5.13
-------
+^^^^^^
 03-Sep-2014
 
 * Fix missing priority plugin in YUM for Fedora when installing
@@ -79,7 +82,7 @@ Changelog
 * Fixed an issue where errors before the logger was setup would be silenced.
 
 1.5.12
-------
+^^^^^^
 25-Aug-2014
 
 * Better traceback reporting with logging.
@@ -89,14 +92,14 @@ Changelog
 * Be able to concatenate and seed keyring files with ``--keyrings``
 
 1.5.11
-------
+^^^^^^
 25-Aug-2014
 
 *  Fix a problem where CentOS7 is not matched correctly against repos (Thanks
   Tom Walsh)
 
 1.5.10
-------
+^^^^^^
 31-Jul-2014
 
 * Use ``ceph-disk`` with high verbosity
@@ -108,7 +111,7 @@ Changelog
 * Work with inconsistent repo sections for Emperor when setting priorities
 
 1.5.9
------
+^^^^^
 14-Jul-2014
 
 * Allow to optionally set the ``fsid`` when calling ``new``
@@ -117,7 +120,7 @@ Changelog
 * Fix new naming scheme for CentOS platforms that prevented CentOS 7 installs
 
 1.5.8
------
+^^^^^
 09-Jul-2014
 
 * Create a flake8/pep8/linting job so that we prevent Undefined errors
@@ -127,27 +130,27 @@ Changelog
 * Fix an ``AttributeError`` in execnet (see https://github.com/alfredodeza/execnet/issues/1)
 
 1.5.7
------
+^^^^^
 01-Jul-2014
 
 * Fix ``NameError`` on osd.py from an undefined variable
 * Fix a calamari connect problem when installing on multiple hosts
 
 1.5.6
------
+^^^^^
 01-Jul-2014
 
 * Optionally avoid vendoring libraries for upstream package maintainers.
 * Fix RHEL7 installation issue that was pulling ``el6`` packages (Thanks David Vossel)
 
 1.5.5
------
+^^^^^
 10-Jun-2014
 
 * Normalize repo file header calls. Fixes breakage on Calamari repos.
 
 1.5.4
------
+^^^^^
 10-Jun-2014
 
 * Improve help by adding online doc link
@@ -156,7 +159,7 @@ Changelog
 * set the right priority for ceph.repo and warn about this
 
 1.5.3
------
+^^^^^
 30-May-2014
 
 * Another fix for IPV6: write correct ``mon_host`` in ceph.conf
@@ -167,21 +170,21 @@ Changelog
 * Use the correct URL repo when installing for RHEL
 
 1.5.2
------
+^^^^^
 09-May-2014
 
 * Remove ``--`` from the command to install packages. (Thanks Vincenzo Pii)
 * Default to Firefly as the latest, stable Ceph version
 
 1.5.1
------
+^^^^^
 01-May-2014
 
 * Fixes a broken ``osd`` command that had the wrong attribute in the conn
   object
 
 1.5.0
------
+^^^^^
 28-Apr-2014
 
 * Warn if ``requiretty`` is causing issues
@@ -194,8 +197,11 @@ Changelog
 * Implement ``osd list`` to list remote osds
 * Fix install issues on Suse (Thanks Owen Synge)
 
-1.4.0
+1.4
 -----
+
+1.4.0
+^^^^^
 * uninstall ceph-release and clean cache in CentOS
 * Add ability to add monitors to an existing cluster
 * Deprecate use of ``--stable`` for releases, introduce ``--release``
@@ -203,8 +209,11 @@ Changelog
 * Enable default ceph-deploy configurations for repo handling
 * Fix wrong URL for rpm installs with ``--testing`` flag
 
+1.3
+---
+
 1.3.5
------
+^^^^^
 * Support Debian SID for installs
 * Error nicely when hosts cannot be resolved
 * Return a non-zero exit status when monitors have not formed quorum
@@ -215,7 +224,7 @@ Changelog
 * remove dry-run flag that did nothing
 
 1.3.4
------
+^^^^^
 * ``/etc/ceph`` now gets completely removed when using ``purgedata``.
 * Refuse to perform ``purgedata`` if ceph is installed
 * Add more details when a given platform is not supported
@@ -225,7 +234,7 @@ Changelog
 
 
 1.3.3
------
+^^^^^
 * Add repo mirror support with ``--repo-url`` and ``--gpg-url``
 * Remove dependency on the ``which`` command
 * Fix problem when removing ``/var/lib/ceph`` and OSDs are still mounted
@@ -235,20 +244,20 @@ Changelog
 
 
 1.3.2
------
+^^^^^
 * ``ceph-deploy new`` will now attempt to copy SSH keys if necessary unless it
   it disabled.
 * Default to Emperor version of ceph when installing.
 
 1.3.1
------
+^^^^^
 * Use ``shutil.move`` to overwrite files from temporary ones (Thanks Mark
   Kirkwood)
 * Fix failure to ``wget`` GPG keys on Debian and Debian-based distros when
   installing
 
-1.3
----
+1.3.0
+^^^^^
 * Major refactoring for all the remote connections in ceph-deploy. With global
   and granular timeouts.
 * Raise the log level for missing keyrings
@@ -259,8 +268,11 @@ Changelog
 * Fix lack of ``--cluster`` usage on monitor error checks
 * ensure we correctly detect Debian releases
 
+1.2
+---
+
 1.2.7
------
+^^^^^
 * Ensure local calls to ceph-deploy do not attempt to ssh.
 * ``mon create-initial`` command to deploy all defined mons, wait for them to
   form quorum and finally to gatherkeys.
@@ -279,17 +291,17 @@ Changelog
   remote hosts.
 
 1.2.6
------
+^^^^^
 * Fixes a problem witha closed connection for Debian distros when creating
   a mon.
 
 1.2.5
------
+^^^^^
 * Fix yet another hanging problem when starting monitors. Closing the
   connection now before we even start them.
 
 1.2.4
------
+^^^^^
 * Improve ``osd help`` menu with path information
 * Really discourage the use of ``ceph-deploy new [IP]``
 * Fix hanging remote requests
@@ -308,7 +320,7 @@ Changelog
 * Fix hanging problem on remote hosts
 
 1.2.3
------
+^^^^^
 * Fix non-working ``disk list``
 * ``check_call`` utility fixes ``$PATH`` issues.
 * Use proper exit codes from the ``main()`` CLI function
@@ -317,7 +329,7 @@ Changelog
 * Report nicely when ``HOST:DISK`` is not used when zapping.
 
 1.2.2
------
+^^^^^
 * Do not force usage of lsb_release, fallback to
   ``platform.linux_distribution()``
 * Ease installation in CentOS/Scientific by adding the EPEL repo
@@ -327,7 +339,7 @@ Changelog
 * Honor the usage of ``--cluster`` when calling osd prepare.
 
 1.2.1
------
+^^^^^
 * Print the help when no arguments are passed
 * Add a ``--version`` flag
 * Show the version in the help menu
@@ -336,9 +348,8 @@ Changelog
 * default to ``dumpling`` for installs
 * halt execution on remote exceptions
 
-
-1.2
----
+1.2.0
+^^^^^
 * Better logging output
 * Remote logging for individual actions for ``install`` and ``mon create``
 * Install ``ca-certificates`` on all Debian-based distros

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,8 @@ Changelog
 
 1.5.22
 ------
+09-Mar-2015
+
 * Enable ``check_obsoletes`` in Yum priorities plugin when deploying
   upstream Ceph on RPM-based distros
 * Require ``--release`` flag to install upstream Ceph on RHEL
@@ -10,6 +12,8 @@ Changelog
 
 1.5.21
 ------
+10-Dec-2014
+
 * Fix distro detection for CentOS and Scientific Linux, which was
   preventing installation of EPEL repo as a prerequisite.
 * Default to Giant on install.
@@ -18,25 +22,35 @@ Changelog
 
 1.5.20
 ------
+13-Nov-2014
+
 * log stderr and stdout in the same order as they happen remotely.
 
 1.5.19
 ------
+29-Oct-2014
+
 * Create temporary ceph.conf files in ``/etc/ceph`` to avoid issues with
   SELinux.
 
 1.5.18
 ------
+09-Oct-2014
+
 * Fix issue for enabling the OSD service in el-like distros.
 * Create a monitor keyring if it doesn't exist.
 
 1.5.17
 ------
+06-Oct-2014
+
 * Do not ask twice for passwords when calling ``new``.
 * Ensure priorities are installed and enforced for custom repositories.
 
 1.5.16
 ------
+30-Sep-2014
+
 * Enable services on ``el`` distros when deploying Ceph daemons.
 * Smarter detection of ``sudo`` need on remote nodes (prevents issues when
   running ceph-deploy as ``root`` or with ``sudo``.
@@ -45,21 +59,29 @@ Changelog
 
 1.5.15
 ------
+12-Sep-2014
+
 * If ``wget`` is installed don't try to install it regardless.
 
 1.5.14
 ------
+09-Sep-2014
+
 * Do not override environment variables on remote hosts, preserve them and
   extend the ``$PATH`` if not explicitly told not to.
 
 1.5.13
 ------
+03-Sep-2014
+
 * Fix missing priority plugin in YUM for Fedora when installing
 * Implement --public-network and --cluster-network with remote IP validation
 * Fixed an issue where errors before the logger was setup would be silenced.
 
 1.5.12
 ------
+25-Aug-2014
+
 * Better traceback reporting with logging.
 * Close stderr/stdout when ceph-deploy completes operations (silences odd
   tracebacks)
@@ -68,11 +90,15 @@ Changelog
 
 1.5.11
 ------
-* Fix a problem where CentOS7 is not matched correctly against repos (Thanks
+25-Aug-2014
+
+*  Fix a problem where CentOS7 is not matched correctly against repos (Thanks
   Tom Walsh)
 
 1.5.10
 ------
+31-Jul-2014
+
 * Use ``ceph-disk`` with high verbosity
 * Don't require ``ceph-common`` on EL distros
 * Use ``ceph-disk zap`` instead of re-implementing it
@@ -83,6 +109,8 @@ Changelog
 
 1.5.9
 -----
+14-Jul-2014
+
 * Allow to optionally set the ``fsid`` when calling ``new``
 * Correctly select sysvinit or systemd for Suse versions (Thanks Owen Synge)
 * Use correct version of remoto (``0.0.19``) that holds the ``None`` global fix
@@ -90,6 +118,8 @@ Changelog
 
 1.5.8
 -----
+09-Jul-2014
+
 * Create a flake8/pep8/linting job so that we prevent Undefined errors
 * Add partprobe/partx calls when zapping disks
 * Fix RHEL7 installation issues (url was using el6 incorrectly) (Thanks David Vossel)
@@ -98,20 +128,28 @@ Changelog
 
 1.5.7
 -----
+01-Jul-2014
+
 * Fix ``NameError`` on osd.py from an undefined variable
 * Fix a calamari connect problem when installing on multiple hosts
 
 1.5.6
 -----
+01-Jul-2014
+
 * Optionally avoid vendoring libraries for upstream package maintainers.
 * Fix RHEL7 installation issue that was pulling ``el6`` packages (Thanks David Vossel)
 
 1.5.5
 -----
+10-Jun-2014
+
 * Normalize repo file header calls. Fixes breakage on Calamari repos.
 
 1.5.4
 -----
+10-Jun-2014
+
 * Improve help by adding online doc link
 * allow cephdeploy.conf to set priorities in repos
 * install priorities plugin for yum distros
@@ -119,6 +157,8 @@ Changelog
 
 1.5.3
 -----
+30-May-2014
+
 * Another fix for IPV6: write correct ``mon_host`` in ceph.conf
 * Support ``proxy`` settings for repo files in YUM
 * Better error message when ceph.conf is not found
@@ -128,16 +168,22 @@ Changelog
 
 1.5.2
 -----
+09-May-2014
+
 * Remove ``--`` from the command to install packages. (Thanks Vincenzo Pii)
 * Default to Firefly as the latest, stable Ceph version
 
 1.5.1
 -----
+01-May-2014
+
 * Fixes a broken ``osd`` command that had the wrong attribute in the conn
   object
 
 1.5.0
 -----
+28-Apr-2014
+
 * Warn if ``requiretty`` is causing issues
 * Support IPV6 host resolution (Thanks Frode Nordahl)
 * Fix incorrect paths for local cephdeploy.conf

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -145,7 +145,7 @@ html_static_path = ['_static']
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+html_use_smartypants = False
 
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -6,10 +6,10 @@ Content Index
 
    index.rst
    changelog.rst
-   install.rst
-   pkg.rst
-   mon.rst
    new.rst
-   conf.rst
+   install.rst
+   mon.rst
    rgw.rst
    mds.rst
+   conf.rst
+   pkg.rst

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -11,3 +11,4 @@ Content Index
    mon.rst
    new.rst
    conf.rst
+   rgw.rst

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -5,7 +5,6 @@ Content Index
    :maxdepth: 2
 
    index.rst
-   changelog.rst
    new.rst
    install.rst
    mon.rst
@@ -13,3 +12,4 @@ Content Index
    mds.rst
    conf.rst
    pkg.rst
+   changelog.rst

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -12,3 +12,4 @@ Content Index
    new.rst
    conf.rst
    rgw.rst
+   mds.rst

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,7 +1,7 @@
 
 .. _install:
 
-``install``
+install
 ===========
 A few different distributions are supported with some flags to allow some
 customization for installing ceph on remote nodes.

--- a/docs/source/mds.rst
+++ b/docs/source/mds.rst
@@ -1,11 +1,11 @@
 .. _mds:
 
-``mds``
+mds
 =======
 The ``mds`` subcommand provides an interface to interact with a cluster's
 CephFS Metadata servers.
 
-``create``
+create
 ----------
 Deploy MDS instances by specifying directly like::
 

--- a/docs/source/mds.rst
+++ b/docs/source/mds.rst
@@ -1,0 +1,20 @@
+.. _mds:
+
+``mds``
+=======
+The ``mds`` subcommand provides an interface to interact with a cluster's
+CephFS Metadata servers.
+
+``create``
+----------
+Deploy MDS instances by specifying directly like::
+
+    ceph-deploy mds create node1 node2 node3
+
+This will create an MDS on the given node(s) and start the
+corresponding service.
+
+The MDS instances will default to having a name corresponding to the hostname
+where it runs.  For example, ``mds.node1``.
+
+.. note:: Removing MDS instances is not yet supported

--- a/docs/source/mon.rst
+++ b/docs/source/mon.rst
@@ -1,13 +1,13 @@
 .. _mon:
 
-``mon``
+mon
 =======
 The ``mon`` subcommand provides an interface to interact with a cluster's
 monitors. The tool makes a few assumptions that are needed to implement the
 most common scenarios. Monitors are usually very particular in what they need
 to work correctly.
 
-``create-initial``
+create-initial
 ------------------
 Will deploy for monitors defined in ``mon initial members``, wait until
 they form quorum and then ``gatherkeys``, reporting the monitor status along
@@ -23,7 +23,7 @@ along the way.
     ceph-deploy mon create-initial
 
 
-``create``
+create
 ----------
 Deploy monitors by specifying directly like::
 
@@ -36,7 +36,7 @@ Please note that if this is an initial monitor deployment, the preferred way
 is to use ``create-initial``.
 
 
-``add``
+add
 -------
 Add a monitor to an existing cluster::
 
@@ -67,7 +67,7 @@ of the provided host.
 .. versionadded:: 1.4.0
 
 
-``destroy``
+destroy
 -----------
 Completely remove monitors on a remote host. Requires hostname(s) as
 arguments::
@@ -75,7 +75,7 @@ arguments::
     ceph-deploy mon destroy node1
 
 
-``--keyrings``
+--keyrings
 --------------
 Both ``create`` and ``create-initial`` subcommands can be used with the
 ``--keyrings`` flag that accepts a path to search for keyring files.

--- a/docs/source/new.rst
+++ b/docs/source/new.rst
@@ -63,7 +63,7 @@ both by external client-facing hosts and internal cluster daemons.
 
 
 --cluster-network --public-network
-==========================================
+----------------------------------
 Are used to provide subnets so that nodes can communicate within that
 network. If passed, validation will occur by looking at the remote IP addresses
 and making sure that at least one of those addresses is valid for the given

--- a/docs/source/new.rst
+++ b/docs/source/new.rst
@@ -1,6 +1,6 @@
 .. _new:
 
-``new``
+new
 =======
 This subcommand is used to generate a working ``ceph.conf`` file that will
 contain important information for provisioning nodes and/or adding them to
@@ -62,7 +62,7 @@ contact to authenticate to the cluster, and they need to be reachable
 both by external client-facing hosts and internal cluster daemons.
 
 
-``--cluster-network`` ``--public-network``
+--cluster-network --public-network
 ==========================================
 Are used to provide subnets so that nodes can communicate within that
 network. If passed, validation will occur by looking at the remote IP addresses

--- a/docs/source/pkg.rst
+++ b/docs/source/pkg.rst
@@ -1,7 +1,7 @@
 
 .. _pkg:
 
-``pkg``
+pkg
 =======
 Provides a simple interface to install or remove packages on a remote host (or
 a number of remote hosts).
@@ -16,7 +16,7 @@ than one package in the argument.
 
 .. _pkg-install:
 
-``--install``
+--install
 -------------
 This flag will use the package (or packages) passed in to perform an installation using
 the distribution package manager in a non-interactive way. Package managers
@@ -38,7 +38,7 @@ An example call to install a few packages on 2 hosts (with hostnames like
 
 .. _pkg-remove:
 
-``--remove``
+--remove
 ------------
 This flag will use the package (or packages) passed in to remove them using
 the distribution package manager in a non-interactive way. Package managers

--- a/docs/source/rgw.rst
+++ b/docs/source/rgw.rst
@@ -1,0 +1,29 @@
+.. _rgw:
+
+``rgw``
+=======
+The ``rgw`` subcommand provides an interface to interact with a cluster's
+RADOS Gateway instances.
+
+``create``
+----------
+Deploy RGW instances by specifying directly like::
+
+    ceph-deploy rgw create node1 node2 node3
+
+This will create an instance of RGW on the given node(s) and start the
+corresponding service. The daemon will listen on the default port of 7480.
+
+The RGW instances will default to having a name corresponding to the hostname
+where it runs.  For example, ``rgw.node1``.
+
+.. note:: If an error is presented about the ``bootstrap-rgw`` keyring not being
+          found, that is because the ``bootstrap-rgw`` only been auto-created on
+          new clusters starting with the Hammer release.
+
+.. versionadded:: 1.5.23
+
+.. note:: Removing RGW instances is not yet supported
+
+.. note:: Changing the port on which RGW will listen at deployment time is not yet
+          supported.

--- a/docs/source/rgw.rst
+++ b/docs/source/rgw.rst
@@ -1,11 +1,11 @@
 .. _rgw:
 
-``rgw``
+rgw
 =======
 The ``rgw`` subcommand provides an interface to interact with a cluster's
 RADOS Gateway instances.
 
-``create``
+create
 ----------
 Deploy RGW instances by specifying directly like::
 


### PR DESCRIPTION
This make several updates to the docs:

* adds new pages for mds and rgw
* changes the layout of the changelog a bit to make things cleaner/easier to navigate
* fixes some section level mistakes (moving sections up one, down one as far a nesting goes)
* adds release dates in the changelog

All builds and displays correctly for me locally.