### PR TITLE
Remove destroy

### DIFF
--- a/ceph_deploy/mds.py
+++ b/ceph_deploy/mds.py
@@ -194,9 +194,8 @@ def make(parser):
         metavar='SUBCOMMAND',
         choices=[
             'create',
-            'destroy',
             ],
-        help='create or destroy',
+        help='create an MDS',
         )
     parser.add_argument(
         'mds',

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -673,9 +673,8 @@ def make(parser):
             'create',
             'prepare',
             'activate',
-            'destroy',
             ],
-        help='list, create (prepare+activate), prepare, activate, or destroy',
+        help='list, create (prepare+activate), prepare, or activate',
         )
     parser.add_argument(
         'disk',

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -192,9 +192,8 @@ def make(parser):
         metavar='SUBCOMMAND',
         choices=[
             'create',
-            'destroy',
             ],
-        help='create or destroy',
+        help='create an RGW instance',
         )
     parser.add_argument(
         'rgw',


### PR DESCRIPTION
Removes unimplemented commands from the argument parser.

Confusing to users to see options that you can't actually use.  :)

Ref: http://tracker.ceph.com/issues/11118