### PR TITLE
Add abstracted get initial monitor member function

### DIFF
--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -58,7 +58,7 @@ def catch_mon_errors(conn, logger, hostname, cfg, args):
     and warn apropriately about it.
     """
     monmap = mon_status_check(conn, logger, hostname, args).get('monmap', {})
-    mon_initial_members = cfg.safe_get('global', 'mon_initial_members')
+    mon_initial_members = get_mon_initial_members(args, _cfg=cfg)
     public_addr = cfg.safe_get('global', 'public_addr')
     public_network = cfg.safe_get('global', 'public_network')
     mon_in_monmap = [
@@ -235,11 +235,7 @@ def mon_create(args):
 
     cfg = conf.ceph.load(args)
     if not args.mon:
-        mon_initial_members = cfg.safe_get('global', 'mon_initial_members')
-        args.mon = re.split(r'[,\s]+', mon_initial_members)
-
-    if not args.mon:
-        raise exc.NeedHostError()
+        args.mon = get_mon_initial_members(args, error_on_empty=True, _cfg=cfg)
 
     if args.keyrings:
         monitor_keyring = concatenate_keyrings(args)
@@ -398,11 +394,7 @@ def mon_destroy(args):
 
 
 def mon_create_initial(args):
-    cfg = conf.ceph.load(args)
-    cfg_initial_members = cfg.safe_get('global', 'mon_initial_members')
-    if cfg_initial_members is None:
-        raise RuntimeError('No `mon initial members` defined in config')
-    mon_initial_members = re.split(r'[,\s]+', cfg_initial_members)
+    mon_initial_members = get_mon_initial_members(args, error_on_empty=True)
 
     # create them normally through mon_create
     mon_create(args)
@@ -534,6 +526,26 @@ def make(parser):
 #
 # Helpers
 #
+
+
+def get_mon_initial_members(args, error_on_empty=False, _cfg=None):
+    """
+    Read the ceph config file and return the value of mon_initial_members
+    Optionally, a NeedHostError can be raised if the value is None.
+    """
+    if _cfg:
+        cfg = _cfg
+    else:
+        cfg = conf.ceph.load(args)
+    mon_initial_members = cfg.safe_get('global', 'mon_initial_members')
+    if not mon_initial_members:
+        if error_on_empty:
+            raise exc.NeedHostError(
+                'could not find `mon initial members` defined in ceph.conf'
+            )
+    else:
+        mon_initial_members = re.split(r'[,\s]+', mon_initial_members)
+    return mon_initial_members
 
 
 def is_running(conn, args):

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 
 from cStringIO import StringIO
 
-from ceph_deploy import conf, exc, hosts
+from ceph_deploy import conf, exc, hosts, mon
 from ceph_deploy.util import constants, system
 from ceph_deploy.cliutil import priority
 from ceph_deploy.lib import remoto
@@ -466,16 +466,7 @@ def disk_list(args, cfg):
 
 
 def osd_list(args, cfg):
-    # FIXME: this portion should probably be abstracted. We do the same in
-    # mon.py
-    cfg = conf.ceph.load(args)
-    mon_initial_members = cfg.safe_get('global', 'mon_initial_members')
-    monitors = re.split(r'[,\s]+', mon_initial_members)
-
-    if not monitors:
-        raise exc.NeedHostError(
-            'could not find `mon initial members` defined in ceph.conf'
-        )
+    monitors = mon.get_mon_initial_members(args, error_on_empty=True, _cfg=cfg)
 
     # get the osd tree from a monitor host
     mon_host = monitors[0]


### PR DESCRIPTION
To get monitor members feature will be reuse serval times in mon.py and osd.py.
Due to this reason, I rewrite the helper function for this feature.

If you have any questions, feel free to let me know.
Thanks!

Signed-off-by: Vicente Cheng <freeze.bilsted@gmail.com>