### PR TITLE
11242 include tox.ini

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include *.rst
 include LICENSE
 include scripts/ceph-deploy
 include vendor.py
+include tox.ini
 prune ceph_deploy/test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,3 @@ include LICENSE
 include scripts/ceph-deploy
 include vendor.py
 include tox.ini
-prune ceph_deploy/test


### PR DESCRIPTION
Include tox.ini in sdist tarball.

Ref: http://tracker.ceph.com/issues/11242