### PR TITLE
Updating the url used to clone the remoto repository

### DIFF
--- a/vendor.py
+++ b/vendor.py
@@ -64,7 +64,7 @@ def vendor_library(name, version, cmd=None):
             run(['rm', '-rf', vendor_dest])
 
     if not path.exists(vendor_dest):
-        run(['git', 'clone', 'git://ceph.com/%s' % name])
+        run(['git', 'clone', 'https://github.com/alfredodeza/%s.git' % name])
         os.chdir(vendor_src)
         run(['git', 'checkout', version])
         if cmd:

--- a/vendor.py
+++ b/vendor.py
@@ -31,6 +31,8 @@ def run(cmd):
     if result.wait():
         print_error(result.stdout.readlines(), result.stderr.readlines())
 
+    return result.returncode
+
 
 def print_error(stdout, stderr):
     print '*'*80

--- a/vendor.py
+++ b/vendor.py
@@ -64,7 +64,7 @@ def vendor_library(name, version, cmd=None):
             run(['rm', '-rf', vendor_dest])
 
     if not path.exists(vendor_dest):
-        run(['git', 'clone', 'https://github.com/alfredodeza/%s.git' % name])
+        run(['git', 'clone', 'https://github.com/ceph/%s.git' % name])
         os.chdir(vendor_src)
         run(['git', 'checkout', version])
         if cmd:

--- a/vendor.py
+++ b/vendor.py
@@ -66,7 +66,10 @@ def vendor_library(name, version, cmd=None):
             run(['rm', '-rf', vendor_dest])
 
     if not path.exists(vendor_dest):
-        run(['git', 'clone', 'https://github.com/ceph/%s.git' % name])
+        rc = run(['git', 'clone', 'git://ceph.com/%s' % name])
+        if (rc):
+            print "%s: git clone failed using ceph.com url with rc %s, trying github.com" % (path.basename(__file__), rc)
+            run(['git', 'clone', 'https://github.com/ceph/%s.git' % name])
         os.chdir(vendor_src)
         run(['git', 'checkout', version])
         if cmd:

--- a/vendor.py
+++ b/vendor.py
@@ -67,7 +67,7 @@ def vendor_library(name, version, cmd=None):
 
     if not path.exists(vendor_dest):
         rc = run(['git', 'clone', 'git://ceph.com/%s' % name])
-        if (rc):
+        if rc:
             print "%s: git clone failed using ceph.com url with rc %s, trying github.com" % (path.basename(__file__), rc)
             run(['git', 'clone', 'https://github.com/ceph/%s.git' % name])
         os.chdir(vendor_src)


### PR DESCRIPTION
Hey guys,

Ran into an issue where the ./bootstrap script used to configure ceph-deploy was trying to pull down a remoto git repo from ceph.com. Updated to direct to Alfredo's remoto repo (heh). I tested this myself, but let me know if there's something I misunderstood. I also took this opportunity to switch to https:// instead of git://...https is much more reliable behind a proxy.

Joe