### PR TITLE
doc: add CVE-2015-3010 to changelog

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,8 +12,8 @@ Changelog
 * Add ``rgw`` command to easily create rgw instances.
 * Automatically install the radosgw package.
 * Remove unimplemented subcommands from CLI and help.
-* Fix an issue where keyring permissions were world readable
-  (thanks Owen Synge).
+* **CVE-2015-3010**: Fix an issue where keyring permissions were
+  world readable (thanks Owen Synge).
 * Fix an issue preventing all but the first host given to
   ``install --repo`` from being used.
 


### PR DESCRIPTION
One of the changes in ceph-deploy 1.5.23 is tracked as CVE-2015-3010. Document this in the changelog.