### PR TITLE
use new remoto version `0.0.25` 

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,13 @@ Changelog
 1.5
 ---
 
+1.5.24
+^^^^^^
+**UNRELEASED**
+
+* Use version 0.0.25 of `remoto` that fixes an issue where output would be cut
+  (https://github.com/alfredodeza/remoto/issues/15).
+
 1.5.23
 ^^^^^^
 07-Apr-2015

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.environ.get('CEPH_DEPLOY_NO_VENDOR'):
     clean_vendor('remoto')
 else:
     vendorize([
-        ('remoto', '0.0.23', ['python', 'vendor.py']),
+        ('remoto', '0.0.25', ['python', 'vendor.py']),
     ])
 
 


### PR DESCRIPTION
That fixes a problem where output would be cut before closing the connection.

Reference issue: http://tracker.ceph.com/issues/11347