### PR TITLE
Better handling of custom RGW daemon names

### DIFF
--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -176,9 +176,10 @@ def rgw(args):
 
 def colon_separated(s):
     host = s
-    name = 'rgw.' + s
+    name = s
     if s.count(':') == 1:
         (host, name) = s.split(':')
+    name = 'rgw.' + name
     return (host, name)
 
 
@@ -200,7 +201,8 @@ def make(parser):
         metavar='HOST[:NAME]',
         nargs='*',
         type=colon_separated,
-        help='host (and optionally the daemon name) to deploy on',
+        help='host (and optionally the daemon name) to deploy on. \
+                NAME is automatically prefixed with \'rgw.\'',
         )
     parser.set_defaults(
         func=rgw,

--- a/ceph_deploy/tests/test_cli_rgw.py
+++ b/ceph_deploy/tests/test_cli_rgw.py
@@ -1,0 +1,38 @@
+import pytest
+import subprocess
+
+import ceph_deploy.rgw as rgw
+
+
+def test_help(tmpdir, cli):
+    with cli(
+        args=['ceph-deploy', 'rgw', '--help'],
+        stdout=subprocess.PIPE,
+        ) as p:
+        result = p.stdout.read()
+    assert 'usage: ceph-deploy rgw' in result
+    assert 'positional arguments' in result
+    assert 'optional arguments' in result
+
+
+def test_bad_no_conf(tmpdir, cli):
+    with tmpdir.join('ceph.conf').open('w'):
+        pass
+    with pytest.raises(cli.Failed) as err:
+        with cli(
+            args=['ceph-deploy', 'rgw'],
+            stderr=subprocess.PIPE,
+            ) as p:
+            result = p.stderr.read()
+    assert 'usage: ceph-deploy rgw' in result
+    assert err.value.status == 2
+
+
+def test_rgw_prefix_auto():
+    daemon = rgw.colon_separated("hostname")
+    assert daemon == ("hostname", "rgw.hostname")
+
+
+def test_rgw_prefix_custom():
+    daemon = rgw.colon_separated("hostname:mydaemon")
+    assert daemon == ("hostname", "rgw.mydaemon")

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 
 * Use version 0.0.25 of `remoto` that fixes an issue where output would be cut
   (https://github.com/alfredodeza/remoto/issues/15).
+* Automatically prefix custom RGW daemon names with 'rgw.'
 
 1.5.23
 ^^^^^^

--- a/docs/source/rgw.rst
+++ b/docs/source/rgw.rst
@@ -17,6 +17,13 @@ corresponding service. The daemon will listen on the default port of 7480.
 The RGW instances will default to having a name corresponding to the hostname
 where it runs.  For example, ``rgw.node1``.
 
+If a custom name is desired for the RGW daemon, it can be specific like::
+
+    ceph-deploy rgw create node1:foo
+
+Custom names are automatically prefixed with "rgw.", so the resulting daemon
+name would be "rgw.foo".
+
 .. note:: If an error is presented about the ``bootstrap-rgw`` keyring not being
           found, that is because the ``bootstrap-rgw`` only been auto-created on
           new clusters starting with the Hammer release.


### PR DESCRIPTION
If a custom RGW daemon name is given, prefix it with 'rgw.'.

Update docs and help to clarify this is done.

Fixes: http://tracker.ceph.com/issues/11561