### PR TITLE
Fix radosgw package name on RPM/EL distros

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -109,7 +109,7 @@ def install(distro, version_kind, version, adjust_repos):
             '-y',
             'install',
             'ceph',
-            'radosgw',
+            'ceph-radosgw',
         ],
     )
 

--- a/ceph_deploy/hosts/centos/uninstall.py
+++ b/ceph_deploy/hosts/centos/uninstall.py
@@ -6,7 +6,7 @@ def uninstall(conn, purge=False):
         'ceph',
         'ceph-release',
         'ceph-common',
-        'radosgw',
+        'ceph-radosgw',
         ]
 
     pkg_managers.yum_remove(

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -80,6 +80,6 @@ def install(distro, version_kind, version, adjust_repos):
             '-q',
             'install',
             'ceph',
-            'radosgw',
+            'ceph-radosgw',
         ],
     )

--- a/ceph_deploy/hosts/fedora/uninstall.py
+++ b/ceph_deploy/hosts/fedora/uninstall.py
@@ -5,7 +5,7 @@ def uninstall(conn, purge=False):
     packages = [
         'ceph',
         'ceph-common',
-        'radosgw',
+        'ceph-radosgw',
         ]
 
     pkg_managers.yum_remove(

--- a/ceph_deploy/hosts/rhel/install.py
+++ b/ceph_deploy/hosts/rhel/install.py
@@ -75,4 +75,4 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
 
     # Some custom repos do not need to install ceph
     if install_ceph:
-        pkg_managers.yum(distro.conn, ['ceph', 'ceph-mon', 'ceph-osd', 'radosgw'])
+        pkg_managers.yum(distro.conn, ['ceph', 'ceph-mon', 'ceph-osd', 'ceph-radosgw'])

--- a/ceph_deploy/hosts/rhel/uninstall.py
+++ b/ceph_deploy/hosts/rhel/uninstall.py
@@ -7,7 +7,7 @@ def uninstall(conn, purge=False):
         'ceph-common',
         'ceph-mon',
         'ceph-osd',
-        'radosgw'
+        'ceph-radosgw'
         ]
 
     pkg_managers.yum_remove(

--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -80,7 +80,7 @@ def install(distro, version_kind, version, adjust_repos):
             '--quiet',
             'install',
             'ceph',
-            'radosgw',
+            'ceph-radosgw',
             ],
         )
 

--- a/ceph_deploy/hosts/suse/uninstall.py
+++ b/ceph_deploy/hosts/suse/uninstall.py
@@ -7,7 +7,7 @@ def uninstall(conn, purge=False):
         'libcephfs1',
         'librados2',
         'librbd1',
-        'radosgw',
+        'ceph-radosgw',
         ]
     cmd = [
         'zypper',


### PR DESCRIPTION
For RPM based systems, the radosgw package is actually 'ceph-radosgw'.  It's 'radosgw' on Debian.

Make sure we install/uninstall the right package!

Signed-off-by: Travis Rhoden <trhoden@redhat.com>