### PR TITLE
Create /var/lib/ceph/radosgw/{cluster}-{name} recursively

### DIFF
--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -296,6 +296,17 @@ def safe_mkdir(path):
             raise
 
 
+def safe_makedirs(path):
+    """ create path recursively if it doesn't exist """
+    try:
+        os.makedirs(path)
+    except OSError, e:
+        if e.errno == errno.EEXIST:
+            pass
+        else:
+            raise
+
+
 def zeroing(dev):
     """ zeroing last few blocks of device """
     # this kills the crab

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -34,7 +34,7 @@ def create_rgw(distro, name, cluster, init):
         name=name
         )
 
-    conn.remote_module.safe_mkdir(path)
+    conn.remote_module.safe_makedirs(path)
 
     bootstrap_keyring = '/var/lib/ceph/bootstrap-rgw/{cluster}.keyring'.format(
         cluster=cluster


### PR DESCRIPTION
Right now the ceph RPM package does not create /var/lib/ceph/radosgw automatically.

ceph-deploy tries to write into  /var/lib/ceph/radosgw/{cluster}-{name}, and fails to create it when /var/lib/ceph/radosgw does not exist. Switch to a os.makedirs call from a os.mkdir call so that it gets done recursively.

This will be safe to keep even if the RPM package starts create /var/lib/ceph/radosgw itself.