### PR TITLE
support for package split

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -61,6 +61,9 @@ def get(hostname,
     module.normalized_release = _normalized_release(release)
     module.distro = module.normalized_name
     module.is_el = module.normalized_name in ['redhat', 'centos', 'fedora', 'scientific']
+    module.is_rpm = module.normalized_name in ['redhat', 'centos',
+                                               'fedora', 'scientific', 'suse']
+    module.is_deb = not module.is_rpm
     module.release = release
     module.codename = codename
     module.conn = conn

--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -34,7 +34,9 @@ def repository_url_part(distro):
     return 'el6'
 
 
-def install(distro, version_kind, version, adjust_repos):
+def install(distro, version_kind, version, adjust_repos, **kw):
+    # note: when split packages for ceph land for CentOS, `kw['components']`
+    # will have those. Unused for now.
     logger = distro.conn.logger
     release = distro.release
     machine = distro.machine_type
@@ -124,7 +126,9 @@ def install_epel(distro):
         pkg_managers.yum(distro.conn, 'epel-release')
 
 
-def mirror_install(distro, repo_url, gpg_url, adjust_repos, extra_installs=True):
+def mirror_install(distro, repo_url, gpg_url, adjust_repos, extra_installs=True, **kw):
+    # note: when split packages for ceph land for CentOS, `kw['components']`
+    # will have those. Unused for now.
     repo_url = repo_url.strip('/')  # Remove trailing slashes
     gpg_url_path = gpg_url.split('file://')[-1]  # Remove file if present
 
@@ -157,6 +161,11 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos, extra_installs=True)
 
 
 def repo_install(distro, reponame, baseurl, gpgkey, **kw):
+    # do we have specific components to install?
+    # removed them from `kw` so that we don't mess with other defauls
+    # note: when split packages for ceph land for CentOS, `packages`
+    # can be used. Unused for now.
+    packages = kw.pop('components', ['ceph', 'ceph-mon', 'ceph-osd'])  # noqa
     logger = distro.conn.logger
     # Get some defaults
     name = kw.pop('name', '%s repo' % reponame)

--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -1,7 +1,6 @@
 from ceph_deploy.util import pkg_managers, templates
 from ceph_deploy.lib import remoto
 from ceph_deploy.hosts.util import install_yum_priorities
-from ceph_deploy.util.constants import default_components
 
 
 def rpm_dist(distro):

--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -1,6 +1,7 @@
 from ceph_deploy.util import pkg_managers, templates
 from ceph_deploy.lib import remoto
 from ceph_deploy.hosts.util import install_yum_priorities
+from ceph_deploy.util.constants import default_components
 
 
 def rpm_dist(distro):
@@ -165,7 +166,7 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     # removed them from `kw` so that we don't mess with other defauls
     # note: when split packages for ceph land for CentOS, `packages`
     # can be used. Unused for now.
-    packages = kw.pop('components', ['ceph', 'ceph-mon', 'ceph-osd'])  # noqa
+    packages = kw.pop('components', default_components) or default_components  # noqa
     logger = distro.conn.logger
     # Get some defaults
     name = kw.pop('name', '%s repo' % reponame)

--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -163,7 +163,7 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos, extra_installs=True,
 
 def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     # do we have specific components to install?
-    # removed them from `kw` so that we don't mess with other defauls
+    # removed them from `kw` so that we don't mess with other defaults
     # note: when split packages for ceph land for CentOS, `packages`
     # can be used. Unused for now.
     packages = kw.pop('components', default_components) or default_components  # noqa

--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -165,7 +165,7 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     # removed them from `kw` so that we don't mess with other defaults
     # note: when split packages for ceph land for CentOS, `packages`
     # can be used. Unused for now.
-    packages = kw.pop('components', default_components) or default_components  # noqa
+    packages = kw.pop('components', [])  # noqa
     logger = distro.conn.logger
     # Get some defaults
     name = kw.pop('name', '%s repo' % reponame)

--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -2,6 +2,7 @@ from urlparse import urlparse
 
 from ceph_deploy.lib import remoto
 from ceph_deploy.util import pkg_managers
+from ceph_deploy.util.constants import default_components
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):
@@ -156,7 +157,7 @@ def repo_install(distro, repo_name, baseurl, gpgkey, **kw):
     # removed them from `kw` so that we don't mess with other defauls
     # note: when split packages for ceph land for CentOS, `packages`
     # can be used. Unused for now.
-    packages = kw.pop('components', ['ceph', 'ceph-mon', 'ceph-osd'])  # noqa
+    packages = kw.pop('components', default_components) or default_components
     # Get some defaults
     safe_filename = '%s.list' % repo_name.replace(' ', '-')
     install_ceph = kw.pop('install_ceph', False)

--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -156,7 +156,7 @@ def repo_install(distro, repo_name, baseurl, gpgkey, **kw):
     # removed them from `kw` so that we don't mess with other defaults
     # note: when split packages for ceph land for Debian/Ubuntu, `packages`
     # can be used. Unused for now.
-    packages = kw.pop('components', default_components) or default_components
+    packages = kw.pop('components', [])
     # Get some defaults
     safe_filename = '%s.list' % repo_name.replace(' ', '-')
     install_ceph = kw.pop('install_ceph', False)

--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -4,7 +4,9 @@ from ceph_deploy.lib import remoto
 from ceph_deploy.util import pkg_managers
 
 
-def install(distro, version_kind, version, adjust_repos):
+def install(distro, version_kind, version, adjust_repos, **kw):
+    # note: when split packages for ceph land for Debian/Ubuntu,
+    # `kw['components']` will have those. Unused for now.
     codename = distro.codename
     machine = distro.machine_type
 
@@ -99,7 +101,9 @@ def install(distro, version_kind, version, adjust_repos):
         )
 
 
-def mirror_install(distro, repo_url, gpg_url, adjust_repos):
+def mirror_install(distro, repo_url, gpg_url, adjust_repos, **kw):
+    # note: when split packages for ceph land for Debian/Ubuntu,
+    # `kw['components']` will have those. Unused for now.
     repo_url = repo_url.strip('/')  # Remove trailing slashes
     gpg_path = gpg_url.split('file://')[-1]
 
@@ -148,6 +152,11 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos):
 
 
 def repo_install(distro, repo_name, baseurl, gpgkey, **kw):
+    # do we have specific components to install?
+    # removed them from `kw` so that we don't mess with other defauls
+    # note: when split packages for ceph land for CentOS, `packages`
+    # can be used. Unused for now.
+    packages = kw.pop('components', ['ceph', 'ceph-mon', 'ceph-osd'])  # noqa
     # Get some defaults
     safe_filename = '%s.list' % repo_name.replace(' ', '-')
     install_ceph = kw.pop('install_ceph', False)

--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -154,8 +154,8 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos, **kw):
 
 def repo_install(distro, repo_name, baseurl, gpgkey, **kw):
     # do we have specific components to install?
-    # removed them from `kw` so that we don't mess with other defauls
-    # note: when split packages for ceph land for CentOS, `packages`
+    # removed them from `kw` so that we don't mess with other defaults
+    # note: when split packages for ceph land for Debian/Ubuntu, `packages`
     # can be used. Unused for now.
     packages = kw.pop('components', default_components) or default_components
     # Get some defaults

--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -2,7 +2,6 @@ from urlparse import urlparse
 
 from ceph_deploy.lib import remoto
 from ceph_deploy.util import pkg_managers
-from ceph_deploy.util.constants import default_components
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -4,7 +4,7 @@ from ceph_deploy.hosts.util import install_yum_priorities
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):
-    # note: when split packages for ceph land for Debian/Ubuntu,
+    # note: when split packages for ceph land for Fedora,
     # `kw['components']` will have those. Unused for now.
     logger = distro.conn.logger
     release = distro.release

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -3,7 +3,9 @@ from ceph_deploy.hosts.centos.install import repo_install, mirror_install  # noq
 from ceph_deploy.hosts.util import install_yum_priorities
 
 
-def install(distro, version_kind, version, adjust_repos):
+def install(distro, version_kind, version, adjust_repos, **kw):
+    # note: when split packages for ceph land for Debian/Ubuntu,
+    # `kw['components']` will have those. Unused for now.
     logger = distro.conn.logger
     release = distro.release
     machine = distro.machine_type

--- a/ceph_deploy/hosts/rhel/install.py
+++ b/ceph_deploy/hosts/rhel/install.py
@@ -3,14 +3,14 @@ from ceph_deploy.lib import remoto
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):
-    packages = kw.get('components', default_components) or default_components
+    packages = kw.get('components', [])
     pkg_managers.yum_clean(distro.conn)
     pkg_managers.yum(distro.conn, packages)
 
 
 def mirror_install(distro, repo_url,
                    gpg_url, adjust_repos, extra_installs=True, **kw):
-    packages = kw.get('components', default_components) or default_components
+    packages = kw.get('components', [])
     repo_url = repo_url.strip('/')  # Remove trailing slashes
     gpg_url_path = gpg_url.split('file://')[-1]  # Remove file if present
 
@@ -40,7 +40,7 @@ def mirror_install(distro, repo_url,
 def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     # do we have specific components to install?
     # removed them from `kw` so that we don't mess with other defaults
-    packages = kw.pop('components', default_components) or default_components
+    packages = kw.pop('components', [])
 
     # Get some defaults
     name = kw.pop('name', '%s repo' % reponame)

--- a/ceph_deploy/hosts/rhel/install.py
+++ b/ceph_deploy/hosts/rhel/install.py
@@ -1,6 +1,5 @@
 from ceph_deploy.util import pkg_managers, templates
 from ceph_deploy.lib import remoto
-from ceph_deploy.util.constants import default_components
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):

--- a/ceph_deploy/hosts/rhel/install.py
+++ b/ceph_deploy/hosts/rhel/install.py
@@ -2,12 +2,15 @@ from ceph_deploy.util import pkg_managers, templates
 from ceph_deploy.lib import remoto
 
 
-def install(distro, version_kind, version, adjust_repos):
+def install(distro, version_kind, version, adjust_repos, **kw):
+    packages = kw.get('components', ['ceph', 'ceph-mon', 'ceph-osd'])
     pkg_managers.yum_clean(distro.conn)
-    pkg_managers.yum(distro.conn, ['ceph', 'ceph-mon', 'ceph-osd'])
+    pkg_managers.yum(distro.conn, packages)
 
 
-def mirror_install(distro, repo_url, gpg_url, adjust_repos, extra_installs=True):
+def mirror_install(distro, repo_url,
+                   gpg_url, adjust_repos, extra_installs=True, **kw):
+    packages = kw.get('components', ['ceph', 'ceph-mon', 'ceph-osd'])
     repo_url = repo_url.strip('/')  # Remove trailing slashes
     gpg_url_path = gpg_url.split('file://')[-1]  # Remove file if present
 
@@ -31,10 +34,14 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos, extra_installs=True)
         distro.conn.remote_module.write_yum_repo(ceph_repo_content)
 
     if extra_installs:
-        pkg_managers.yum(distro.conn, ['ceph', 'ceph-mon', 'ceph-osd'])
+        pkg_managers.yum(distro.conn, packages)
 
 
 def repo_install(distro, reponame, baseurl, gpgkey, **kw):
+    # do we have specific components to install?
+    # removed them from `kw` so that we don't mess with other defauls
+    packages = kw.pop('components', ['ceph', 'ceph-mon', 'ceph-osd'])
+
     # Get some defaults
     name = kw.pop('name', '%s repo' % reponame)
     enabled = kw.pop('enabled', 1)
@@ -75,4 +82,4 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
 
     # Some custom repos do not need to install ceph
     if install_ceph:
-        pkg_managers.yum(distro.conn, ['ceph', 'ceph-mon', 'ceph-osd', 'radosgw'])
+        pkg_managers.yum(distro.conn, packages)

--- a/ceph_deploy/hosts/rhel/install.py
+++ b/ceph_deploy/hosts/rhel/install.py
@@ -1,16 +1,17 @@
 from ceph_deploy.util import pkg_managers, templates
 from ceph_deploy.lib import remoto
+from ceph_deploy.util.constants import default_components
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):
-    packages = kw.get('components', ['ceph', 'ceph-mon', 'ceph-osd'])
+    packages = kw.get('components', default_components) or default_components
     pkg_managers.yum_clean(distro.conn)
     pkg_managers.yum(distro.conn, packages)
 
 
 def mirror_install(distro, repo_url,
                    gpg_url, adjust_repos, extra_installs=True, **kw):
-    packages = kw.get('components', ['ceph', 'ceph-mon', 'ceph-osd'])
+    packages = kw.get('components', default_components) or default_components
     repo_url = repo_url.strip('/')  # Remove trailing slashes
     gpg_url_path = gpg_url.split('file://')[-1]  # Remove file if present
 
@@ -40,7 +41,7 @@ def mirror_install(distro, repo_url,
 def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     # do we have specific components to install?
     # removed them from `kw` so that we don't mess with other defauls
-    packages = kw.pop('components', ['ceph', 'ceph-mon', 'ceph-osd'])
+    packages = kw.pop('components', default_components) or default_components
 
     # Get some defaults
     name = kw.pop('name', '%s repo' % reponame)

--- a/ceph_deploy/hosts/rhel/install.py
+++ b/ceph_deploy/hosts/rhel/install.py
@@ -40,7 +40,7 @@ def mirror_install(distro, repo_url,
 
 def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     # do we have specific components to install?
-    # removed them from `kw` so that we don't mess with other defauls
+    # removed them from `kw` so that we don't mess with other defaults
     packages = kw.pop('components', default_components) or default_components
 
     # Get some defaults

--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -1,6 +1,8 @@
 from ceph_deploy.util import templates, pkg_managers
 from ceph_deploy.lib import remoto
+from ceph_deploy.util.constants import default_components
 import logging
+
 LOG = logging.getLogger(__name__)
 
 
@@ -128,7 +130,7 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     # removed them from `kw` so that we don't mess with other defauls
     # note: when split packages for ceph land for CentOS, `packages`
     # can be used. Unused for now.
-    packages = kw.pop('components', ['ceph', 'ceph-mon', 'ceph-osd'])  # noqa
+    packages = kw.pop('components', default_components) or default_components  # noqa
     # Get some defaults
     name = kw.get('name', '%s repo' % reponame)
     enabled = kw.get('enabled', 1)

--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -4,7 +4,9 @@ import logging
 LOG = logging.getLogger(__name__)
 
 
-def install(distro, version_kind, version, adjust_repos):
+def install(distro, version_kind, version, adjust_repos, **kw):
+    # note: when split packages for ceph land for Suse,
+    # `kw['components']` will have those. Unused for now.
     release = distro.release
     machine = distro.machine_type
 
@@ -85,7 +87,9 @@ def install(distro, version_kind, version, adjust_repos):
         )
 
 
-def mirror_install(distro, repo_url, gpg_url, adjust_repos):
+def mirror_install(distro, repo_url, gpg_url, adjust_repos, **kw):
+    # note: when split packages for ceph land for Suse,
+    # `kw['components']` will have those. Unused for now.
     repo_url = repo_url.strip('/')  # Remove trailing slashes
     gpg_url_path = gpg_url.split('file://')[-1]  # Remove file if present
 
@@ -120,6 +124,11 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos):
 
 
 def repo_install(distro, reponame, baseurl, gpgkey, **kw):
+    # do we have specific components to install?
+    # removed them from `kw` so that we don't mess with other defauls
+    # note: when split packages for ceph land for CentOS, `packages`
+    # can be used. Unused for now.
+    packages = kw.pop('components', ['ceph', 'ceph-mon', 'ceph-osd'])  # noqa
     # Get some defaults
     name = kw.get('name', '%s repo' % reponame)
     enabled = kw.get('enabled', 1)

--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -1,6 +1,5 @@
 from ceph_deploy.util import templates, pkg_managers
 from ceph_deploy.lib import remoto
-from ceph_deploy.util.constants import default_components
 import logging
 
 LOG = logging.getLogger(__name__)

--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -129,7 +129,7 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     # removed them from `kw` so that we don't mess with other defaults
     # note: when split packages for ceph land for Suse, `packages`
     # can be used. Unused for now.
-    packages = kw.pop('components', default_components) or default_components  # noqa
+    packages = kw.pop('components', [])  # noqa
     # Get some defaults
     name = kw.get('name', '%s repo' % reponame)
     enabled = kw.get('enabled', 1)

--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -127,8 +127,8 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos, **kw):
 
 def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     # do we have specific components to install?
-    # removed them from `kw` so that we don't mess with other defauls
-    # note: when split packages for ceph land for CentOS, `packages`
+    # removed them from `kw` so that we don't mess with other defaults
+    # note: when split packages for ceph land for Suse, `packages`
     # can be used. Unused for now.
     packages = kw.pop('components', default_components) or default_components  # noqa
     # Get some defaults

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -5,7 +5,7 @@ import os
 from ceph_deploy import hosts
 from ceph_deploy.cliutil import priority
 from ceph_deploy.lib import remoto
-
+from ceph_deploy.util.constants import default_components
 
 LOG = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ def detect_components(args):
         'install_ceph': 'ceph',
     }
     if args.install_all:
-        return ['ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw']
+        return default_components
     else:
         components = []
         for k, v in flags.items():

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -28,7 +28,7 @@ def sanitize_args(args):
     return args
 
 
-def detect_components(args):
+def detect_components(args, distro):
     """
     Since the package split, now there are various different ceph components to
     install like:
@@ -49,8 +49,16 @@ def detect_components(args):
         'install_mon': 'ceph-mon',
         'install_ceph': 'ceph',
     }
+
+    if distro.is_rpm:
+        defaults = default_components.rpm
+    else:
+        defaults = default_components.deb
+        # different naming convention for deb than rpm for radosgw
+        flags['install_rgw'] = 'radosgw'
+
     if args.install_all:
-        return default_components
+        return defaults
     else:
         components = []
         for k, v in flags.items():

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -42,6 +42,13 @@ def detect_components(args, distro):
     these flags and return the default if none are passed in (which is, install
     everything)
     """
+    # the flag that prevents all logic here is the `--repo` flag which is used
+    # when no packages should be installed, just the repo files, so check for
+    # that here and return an empty list (which is equivalent to say 'no
+    # packages should be installed')
+    if args.repo:
+        return []
+
     flags = {
         'install_osd': 'ceph-osd',
         'install_rgw': 'ceph-radosgw',
@@ -63,7 +70,10 @@ def detect_components(args, distro):
         for k, v in flags.items():
             if getattr(args, k, False):
                 components.append(v)
-        return components
+        # if we have some components selected from flags then return that,
+        # otherwise return defaults because no flags and no `--repo` means we
+        # should get all of them by default
+        return components or defaults
 
 
 def install(args):

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -464,14 +464,14 @@ def make(parser):
         '--mon',
         dest='install_mon',
         action='store_true',
-        help='install install the mon component only',
+        help='install the mon component only',
     )
 
     version.add_argument(
         '--mds',
         dest='install_mds',
         action='store_true',
-        help='install install the mds component only',
+        help='install the mds component only',
     )
 
     version.add_argument(
@@ -492,7 +492,7 @@ def make(parser):
         '--all',
         dest='install_all',
         action='store_true',
-        help='install all ceph components (e.g. mon,osd,mds,rgw)',
+        help='install all ceph components (e.g. mon,osd,mds,rgw). This is the default',
     )
 
     version.add_argument(

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -61,6 +61,8 @@ def detect_components(args):
 
 def install(args):
     args = sanitize_args(args)
+    components = detect_components(arg)
+
     if args.repo:
         return install_repo(args)
 
@@ -145,7 +147,8 @@ def install(args):
                 distro,
                 repo_url,
                 gpg_url,
-                args.adjust_repos
+                args.adjust_repos,
+                components=components,
             )
 
         # Detect and install custom repos here if needed
@@ -158,7 +161,8 @@ def install(args):
                 distro,
                 args.version_kind,
                 version,
-                args.adjust_repos
+                args.adjust_repos,
+                components=components,
             )
 
         # Check the ceph version we just installed
@@ -193,6 +197,7 @@ def custom_repo(distro, args, cd_conf, rlogger, install_ceph=None):
     used.
     """
     default_repo = cd_conf.get_default_repo()
+    components = detect_components(args)
     if args.release in cd_conf.get_repos():
         LOG.info('will use repository from conf: %s' % args.release)
         default_repo = args.release
@@ -215,6 +220,7 @@ def custom_repo(distro, args, cd_conf, rlogger, install_ceph=None):
                 default_repo,
                 options.pop('baseurl'),
                 options.pop('gpgkey'),
+                components=components,
                 **options
             )
         except KeyError as err:
@@ -229,6 +235,7 @@ def custom_repo(distro, args, cd_conf, rlogger, install_ceph=None):
                     xrepo,
                     options.pop('baseurl'),
                     options.pop('gpgkey'),
+                    components=components,
                     **options
                 )
             except KeyError as err:

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -423,6 +423,41 @@ def make(parser):
     )
 
     version.add_argument(
+        '--mon',
+        dest='install_mon',
+        action='store_true',
+        help='install install the mon component only',
+    )
+
+    version.add_argument(
+        '--mds',
+        dest='install_mds',
+        action='store_true',
+        help='install install the mds component only',
+    )
+
+    version.add_argument(
+        '--rgw',
+        dest='install_rgw',
+        action='store_true',
+        help='install the rgw component only',
+    )
+
+    version.add_argument(
+        '--osd',
+        dest='install_osd',
+        action='store_true',
+        help='install the osd component only',
+    )
+
+    version.add_argument(
+        '--all',
+        dest='install_all',
+        action='store_true',
+        help='install all ceph components (e.g. mon,osd,mds,rgw)',
+    )
+
+    version.add_argument(
         '--adjust-repos',
         dest='adjust_repos',
         action='store_true',

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -61,7 +61,7 @@ def detect_components(args):
 
 def install(args):
     args = sanitize_args(args)
-    components = detect_components(arg)
+    components = detect_components(args)
 
     if args.repo:
         return install_repo(args)

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -69,7 +69,6 @@ def detect_components(args, distro):
 
 def install(args):
     args = sanitize_args(args)
-    components = detect_components(args)
 
     if args.repo:
         return install_repo(args)
@@ -99,8 +98,8 @@ def install(args):
             # upstream. If default_release is True, it means that the user is
             # trying to install on a RHEL machine and should expect to get RHEL
             # packages. Otherwise, it will need to specify either a specific
-            # version, or repo, or a development branch. Other distro users should
-            # not see any differences.
+            # version, or repo, or a development branch. Other distro users
+            # should not see any differences.
             use_rhceph=args.default_release,
             )
         LOG.info(
@@ -110,6 +109,7 @@ def install(args):
             distro.codename
         )
 
+        components = detect_components(args, distro)
         if distro.init == 'sysvinit' and args.cluster != 'ceph':
             LOG.error('refusing to install on host: %s, with custom cluster name: %s' % (
                     hostname,
@@ -205,7 +205,7 @@ def custom_repo(distro, args, cd_conf, rlogger, install_ceph=None):
     used.
     """
     default_repo = cd_conf.get_default_repo()
-    components = detect_components(args)
+    components = detect_components(args, distro)
     if args.release in cd_conf.get_repos():
         LOG.info('will use repository from conf: %s' % args.release)
         default_repo = args.release

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -47,7 +47,6 @@ def detect_components(args, distro):
         'install_rgw': 'ceph-radosgw',
         'install_mds': 'ceph-mds',
         'install_mon': 'ceph-mon',
-        'install_ceph': 'ceph',
     }
 
     if distro.is_rpm:

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -42,7 +42,21 @@ def detect_components(args):
     these flags and return the default if none are passed in (which is, install
     everything)
     """
-    pass
+    flags = {
+        'install_osd': 'ceph-osd',
+        'install_rgw': 'ceph-radosgw',
+        'install_mds': 'ceph-mds',
+        'install_mon': 'ceph-mon',
+        'install_ceph': 'ceph',
+    }
+    if args.install_all:
+        return ['ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw']
+    else:
+        components = []
+        for k, v in flags.items():
+            if getattr(args, k, False):
+                components.append(v)
+        return components
 
 
 def install(args):

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -28,6 +28,23 @@ def sanitize_args(args):
     return args
 
 
+def detect_components(args):
+    """
+    Since the package split, now there are various different ceph components to
+    install like:
+
+    * ceph
+    * ceph-mon
+    * ceph-osd
+    * ceph-mds
+
+    This helper function should parse the args that may contain specifics about
+    these flags and return the default if none are passed in (which is, install
+    everything)
+    """
+    pass
+
+
 def install(args):
     args = sanitize_args(args)
     if args.repo:

--- a/ceph_deploy/tests/test_install.py
+++ b/ceph_deploy/tests/test_install.py
@@ -57,7 +57,7 @@ class TestDetectComponents(object):
         self.distro.is_deb = True
         result = sorted(install.detect_components(self.args, self.distro))
         assert result == sorted([
-            'ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'radosgw'
+            'ceph-osd', 'ceph-mds', 'ceph-mon', 'radosgw'
         ])
 
     def test_install_all_with_other_options_returns_all_packages_deb(self):
@@ -69,7 +69,7 @@ class TestDetectComponents(object):
         self.args.install_osd = True
         result = sorted(install.detect_components(self.args, self.distro))
         assert result == sorted([
-            'ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'radosgw'
+            'ceph-osd', 'ceph-mds', 'ceph-mon', 'radosgw'
         ])
 
 
@@ -77,7 +77,7 @@ class TestDetectComponents(object):
         self.args.install_all = True
         result = sorted(install.detect_components(self.args, self.distro))
         assert result == sorted([
-            'ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw'
+            'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw'
         ])
 
     def test_install_all_with_other_options_returns_all_packages_rpm(self):
@@ -87,7 +87,7 @@ class TestDetectComponents(object):
         self.args.install_osd = True
         result = sorted(install.detect_components(self.args, self.distro))
         assert result == sorted([
-            'ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw'
+            'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw'
         ])
 
     def test_install_only_one_component(self):

--- a/ceph_deploy/tests/test_install.py
+++ b/ceph_deploy/tests/test_install.py
@@ -49,31 +49,54 @@ class TestDetectComponents(object):
         self.args.install_osd = False
         self.args.install_rgw = False
         self.args.install_ceph = False
+        self.distro = Mock()
 
-    def test_install_all_returns_all_packages(self):
+    def test_install_all_returns_all_packages_deb(self):
         self.args.install_all = True
-        result = sorted(install.detect_components(self.args))
+        self.distro.is_rpm = False
+        self.distro.is_deb = True
+        result = sorted(install.detect_components(self.args, self.distro))
         assert result == sorted([
-            'ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw'
+            'ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'radosgw'
         ])
 
-    def test_install_all_with_other_options_returns_all_packages(self):
+    def test_install_all_with_other_options_returns_all_packages_deb(self):
+        self.distro.is_rpm = False
+        self.distro.is_deb = True
         self.args.install_all = True
         self.args.install_mds = True
         self.args.install_mon = True
         self.args.install_osd = True
-        result = sorted(install.detect_components(self.args))
+        result = sorted(install.detect_components(self.args, self.distro))
+        assert result == sorted([
+            'ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'radosgw'
+        ])
+
+
+    def test_install_all_returns_all_packages_rpm(self):
+        self.args.install_all = True
+        result = sorted(install.detect_components(self.args, self.distro))
+        assert result == sorted([
+            'ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw'
+        ])
+
+    def test_install_all_with_other_options_returns_all_packages_rpm(self):
+        self.args.install_all = True
+        self.args.install_mds = True
+        self.args.install_mon = True
+        self.args.install_osd = True
+        result = sorted(install.detect_components(self.args, self.distro))
         assert result == sorted([
             'ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw'
         ])
 
     def test_install_only_one_component(self):
         self.args.install_osd = True
-        result = install.detect_components(self.args)
+        result = install.detect_components(self.args, self.distro)
         assert result == ['ceph-osd']
 
     def test_install_a_couple_of_components(self):
         self.args.install_osd = True
         self.args.install_mds = True
-        result = sorted(install.detect_components(self.args))
+        result = sorted(install.detect_components(self.args, self.distro))
         assert result == sorted(['ceph-osd', 'ceph-mds'])

--- a/ceph_deploy/tests/test_install.py
+++ b/ceph_deploy/tests/test_install.py
@@ -36,3 +36,44 @@ class TestSanitizeArgs(object):
         self.args.release = 'dumpling'
         result = install.sanitize_args(self.args)
         assert result.stable is None
+
+
+class TestDetectComponents(object):
+
+    def setup(self):
+        self.args = Mock()
+        # default values for install_* flags
+        self.args.install_all = False
+        self.args.install_mds = False
+        self.args.install_mon = False
+        self.args.install_osd = False
+        self.args.install_rgw = False
+        self.args.install_ceph = False
+
+    def test_install_all_returns_all_packages(self):
+        self.args.install_all = True
+        result = install.detect_components(self.args)
+        assert result == [
+            'ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw'
+        ]
+
+    def test_install_all_with_other_options_returns_all_packages(self):
+        self.args.install_all = True
+        self.args.install_mds = True
+        self.args.install_mon = True
+        self.args.install_osd = True
+        result = sorted(install.detect_components(self.args))
+        assert result == sorted([
+            'ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw'
+        ])
+
+    def test_install_only_one_component(self):
+        self.args.install_osd = True
+        result = install.detect_components(self.args)
+        assert result == ['ceph-osd']
+
+    def test_install_a_couple_of_components(self):
+        self.args.install_osd = True
+        self.args.install_mds = True
+        result = install.detect_components(self.args)
+        assert result == ['ceph-osd', 'ceph-mds']

--- a/ceph_deploy/tests/test_install.py
+++ b/ceph_deploy/tests/test_install.py
@@ -52,10 +52,10 @@ class TestDetectComponents(object):
 
     def test_install_all_returns_all_packages(self):
         self.args.install_all = True
-        result = install.detect_components(self.args)
-        assert result == [
+        result = sorted(install.detect_components(self.args))
+        assert result == sorted([
             'ceph', 'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw'
-        ]
+        ])
 
     def test_install_all_with_other_options_returns_all_packages(self):
         self.args.install_all = True

--- a/ceph_deploy/tests/test_install.py
+++ b/ceph_deploy/tests/test_install.py
@@ -49,7 +49,13 @@ class TestDetectComponents(object):
         self.args.install_osd = False
         self.args.install_rgw = False
         self.args.install_ceph = False
+        self.args.repo = False
         self.distro = Mock()
+
+    def test_install_with_repo_option_returns_no_packages(self):
+        self.args.repo = True
+        result = install.detect_components(self.args, self.distro)
+        assert result == []
 
     def test_install_all_returns_all_packages_deb(self):
         self.args.install_all = True
@@ -71,7 +77,6 @@ class TestDetectComponents(object):
         assert result == sorted([
             'ceph-osd', 'ceph-mds', 'ceph-mon', 'radosgw'
         ])
-
 
     def test_install_all_returns_all_packages_rpm(self):
         self.args.install_all = True
@@ -100,3 +105,9 @@ class TestDetectComponents(object):
         self.args.install_mds = True
         result = sorted(install.detect_components(self.args, self.distro))
         assert result == sorted(['ceph-osd', 'ceph-mds'])
+
+    def test_install_all_should_be_default_when_no_options_passed(self):
+        result = sorted(install.detect_components(self.args, self.distro))
+        assert result == sorted([
+            'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw'
+        ])

--- a/ceph_deploy/tests/test_install.py
+++ b/ceph_deploy/tests/test_install.py
@@ -75,5 +75,5 @@ class TestDetectComponents(object):
     def test_install_a_couple_of_components(self):
         self.args.install_osd = True
         self.args.install_mds = True
-        result = install.detect_components(self.args)
-        assert result == ['ceph-osd', 'ceph-mds']
+        result = sorted(install.detect_components(self.args))
+        assert result == sorted(['ceph-osd', 'ceph-mds'])

--- a/ceph_deploy/util/constants.py
+++ b/ceph_deploy/util/constants.py
@@ -20,7 +20,6 @@ _base_components = [
     'ceph-osd',
     'ceph-mds',
     'ceph-mon',
-    'ceph',
 ]
 
 default_components = namedtuple('DefaultComponents', ['rpm', 'deb'])

--- a/ceph_deploy/util/constants.py
+++ b/ceph_deploy/util/constants.py
@@ -1,4 +1,5 @@
 from os.path import join
+from collections import namedtuple
 
 # Base Path for ceph
 base_path = '/var/lib/ceph'
@@ -15,10 +16,16 @@ mds_path = join(base_path, 'mds')
 osd_path = join(base_path, 'osd')
 
 # Default package components to install
-default_components = (
+_base_components = [
     'ceph-osd',
-    'ceph-radosgw',
     'ceph-mds',
     'ceph-mon',
     'ceph',
-)
+]
+
+default_components = namedtuple('DefaultComponents', ['rpm', 'deb'])
+
+# the difference here is because RPMs currently name the radosgw differently than DEBs.
+# TODO: This needs to get unified once the packaging naming gets consistent
+default_components.rpm = tuple(_base_components.append('ceph-radosgw'))
+default_components.deb = tuple(_base_components.append('radosgw'))

--- a/ceph_deploy/util/constants.py
+++ b/ceph_deploy/util/constants.py
@@ -27,5 +27,5 @@ default_components = namedtuple('DefaultComponents', ['rpm', 'deb'])
 
 # the difference here is because RPMs currently name the radosgw differently than DEBs.
 # TODO: This needs to get unified once the packaging naming gets consistent
-default_components.rpm = tuple(_base_components.append('ceph-radosgw'))
-default_components.deb = tuple(_base_components.append('radosgw'))
+default_components.rpm = tuple(_base_components + ['ceph-radosgw'])
+default_components.deb = tuple(_base_components + ['radosgw'])

--- a/ceph_deploy/util/constants.py
+++ b/ceph_deploy/util/constants.py
@@ -13,3 +13,12 @@ mon_path = join(base_path, 'mon')
 mds_path = join(base_path, 'mds')
 
 osd_path = join(base_path, 'osd')
+
+# Default package components to install
+default_components = (
+    'ceph-osd',
+    'ceph-radosgw',
+    'ceph-mds',
+    'ceph-mon',
+    'ceph',
+)


### PR DESCRIPTION
Only supports the package split by using the new packages for RHEL systems only *unless* specified with the new flags. No other distro is affected although the changes should allow to turn this feature "on" at a later point.

Reference ticket: http://tracker.ceph.com/issues/10894