### PR TITLE
MDS: systemd enable

### DIFF
--- a/ceph_deploy/mds.py
+++ b/ceph_deploy/mds.py
@@ -34,7 +34,7 @@ def create_mds(distro, name, cluster, init):
         name=name
         )
 
-    conn.remote_module.safe_mkdir(path)
+    conn.remote_module.makedir(path, [errno.EEXIST])
 
     bootstrap_keyring = '/var/lib/ceph/bootstrap-mds/{cluster}.keyring'.format(
         cluster=cluster

--- a/ceph_deploy/mds.py
+++ b/ceph_deploy/mds.py
@@ -108,6 +108,16 @@ def create_mds(distro, name, cluster, init):
             ],
             timeout=7
         )
+    elif init == 'systemd':
+        remoto.process.run(
+            conn,
+            [
+                'systemctl',
+                'enable',
+                'ceph-mds@{name}'.format(name=name),
+            ],
+            timeout=7
+        )
 
     if distro.is_el:
         system.enable_service(distro.conn)


### PR DESCRIPTION
MDS is not enabled if the distribution uses systemd. Add support for distros using systemd.
Also fixed a directory creation fail in case of a new installation while create.