### PR TITLE
mds: enable on create with systemd

### DIFF
--- a/ceph_deploy/mds.py
+++ b/ceph_deploy/mds.py
@@ -108,6 +108,16 @@ def create_mds(distro, name, cluster, init):
             ],
             timeout=7
         )
+    elif init == 'systemd':
+        remoto.process.run(
+            conn,
+            [
+                'systemctl',
+                'enable',
+                'ceph-mds@{name}'.format(name=name),
+            ],
+            timeout=7
+        )
 
     if distro.is_el:
         system.enable_service(distro.conn)


### PR DESCRIPTION
Enable MDS services for distros using systemd.

Signed-off-by: Goldwyn Rodrigues <rgoldwyn@suse.com>