### PR TITLE
Add --cli/--common option to ceph-deploy install

### DIFF
--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -54,6 +54,7 @@ def detect_components(args, distro):
         'install_rgw': 'ceph-radosgw',
         'install_mds': 'ceph-mds',
         'install_mon': 'ceph-mon',
+        'install_common': 'ceph-common',
     }
 
     if distro.is_rpm:
@@ -503,6 +504,13 @@ def make(parser):
         dest='install_osd',
         action='store_true',
         help='install the osd component only',
+    )
+
+    version.add_argument(
+        '--cli', '--common',
+        dest='install_common',
+        action='store_true',
+        help='install the common component only',
     )
 
     version.add_argument(

--- a/ceph_deploy/tests/test_install.py
+++ b/ceph_deploy/tests/test_install.py
@@ -49,7 +49,6 @@ class TestDetectComponents(object):
         self.args.install_osd = False
         self.args.install_rgw = False
         self.args.install_common = False
-        self.args.install_ceph = False
         self.args.repo = False
         self.distro = Mock()
 

--- a/ceph_deploy/tests/test_install.py
+++ b/ceph_deploy/tests/test_install.py
@@ -48,6 +48,7 @@ class TestDetectComponents(object):
         self.args.install_mon = False
         self.args.install_osd = False
         self.args.install_rgw = False
+        self.args.install_common = False
         self.args.install_ceph = False
         self.args.repo = False
         self.distro = Mock()


### PR DESCRIPTION
This is a convenience option for users setting "admin" nodes.  If a user is going to run ``ceph-deploy admin`` on a node, the only package it really needs on that node to use the CLI is ``ceph-common``.  We had no way to allow a user to only install that.

This feature builds on top of the package split support, and thus this option only works on distros/versions with the package split in place.  Right now that is only downstream RHCS.

``ceph-common`` does not need to be added the default list of packages anywhere because it is always a dependency when it is needed.