### PR TITLE
Disallow custom cluster names with 'new' command and sysvinit hosts

### DIFF
--- a/ceph_deploy/exc.py
+++ b/ceph_deploy/exc.py
@@ -97,6 +97,17 @@ class GenericError(DeployError):
         return self.message
 
 
+class ClusterNameError(DeployError):
+    """
+    Problem encountered with custom cluster name
+    """
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+
 class KeyNotFoundError(DeployError):
     """
     Could not find keyring file

--- a/ceph_deploy/new.py
+++ b/ceph_deploy/new.py
@@ -143,6 +143,14 @@ def new(args):
         # Now get the non-local IPs from the remote node
         distro = hosts.get(host, username=args.username)
         remote_ips = net.ip_addresses(distro.conn)
+
+        # custom cluster names on sysvinit hosts won't work
+        if distro.init == 'sysvinit' and args.cluster != 'ceph':
+            LOG.error('custom cluster names are not supported on sysvinit hosts')
+            raise exc.ClusterNameError(
+                'host %s does not support custom cluster names' % host
+            )
+
         distro.conn.exit()
 
         # Validate subnets if we received any


### PR DESCRIPTION
We know that custom names are not supported with the sysvinit scripts, and we check for this when doing ``ceph-deploy install``, but not ``ceph-deploy new``.  This means that we happily create new Ceph config files that aren't going to be useful if any of the initial monitors use sysvinit.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1222505