### PR TITLE
suse.uninstall: ceph-deploy purge fails on SUSE.

### DIFF
--- a/ceph_deploy/hosts/suse/uninstall.py
+++ b/ceph_deploy/hosts/suse/uninstall.py
@@ -7,7 +7,7 @@ def uninstall(conn, purge=False):
         'libcephfs1',
         'librados2',
         'librbd1',
-        'radosgw',
+        'ceph-radosgw',
         ]
     cmd = [
         'zypper',


### PR DESCRIPTION
This is because ceph-deploy tries to remove a package that does not exist.

To fix this we need to change package name to correct name ceph-radosgw
from the old name radosgw.

Signed-off-by: Owen Synge <osynge@suse.com>