### PR TITLE
Enable systemd services for suse.

### DIFF
--- a/ceph_deploy/mds.py
+++ b/ceph_deploy/mds.py
@@ -122,6 +122,8 @@ def create_mds(distro, name, cluster, init):
     if distro.is_el:
         system.enable_service(distro.conn)
 
+    if distro.distro == 'suse':
+        system.enable_service(distro.conn, 'ceph')
 
 def mds_create(args):
     cfg = conf.ceph.load(args)

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -385,6 +385,8 @@ def activate(args, cfg):
         if distro.is_el:
             system.enable_service(distro.conn)
 
+        if distro.distro == 'suse':
+            system.enable_service(distro.conn, 'ceph')
         distro.conn.exit()
 
 


### PR DESCRIPTION
Make sure systemd is enabled on the suse platform

Signed-off-by: Owen Synge osynge@suse.com
