### PR TITLE
[BZ-1221830] radosgw pkg is ceph-radosgw on RPM systems

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -111,7 +111,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
             '-y',
             'install',
             'ceph',
-            'radosgw',
+            'ceph-radosgw',
         ],
     )
 

--- a/ceph_deploy/hosts/centos/uninstall.py
+++ b/ceph_deploy/hosts/centos/uninstall.py
@@ -6,7 +6,7 @@ def uninstall(conn, purge=False):
         'ceph',
         'ceph-release',
         'ceph-common',
-        'radosgw',
+        'ceph-radosgw',
         ]
 
     pkg_managers.yum_remove(

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -82,6 +82,6 @@ def install(distro, version_kind, version, adjust_repos, **kw):
             '-q',
             'install',
             'ceph',
-            'radosgw',
+            'ceph-radosgw',
         ],
     )

--- a/ceph_deploy/hosts/fedora/uninstall.py
+++ b/ceph_deploy/hosts/fedora/uninstall.py
@@ -5,7 +5,7 @@ def uninstall(conn, purge=False):
     packages = [
         'ceph',
         'ceph-common',
-        'radosgw',
+        'ceph-radosgw',
         ]
 
     pkg_managers.yum_remove(

--- a/ceph_deploy/hosts/rhel/uninstall.py
+++ b/ceph_deploy/hosts/rhel/uninstall.py
@@ -7,7 +7,7 @@ def uninstall(conn, purge=False):
         'ceph-common',
         'ceph-mon',
         'ceph-osd',
-        'radosgw'
+        'ceph-radosgw'
         ]
 
     pkg_managers.yum_remove(

--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -92,7 +92,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
             '--quiet',
             'install',
             'ceph',
-            'radosgw',
+            'ceph-radosgw',
             ],
         )
 


### PR DESCRIPTION
I incorrectly thought in https://github.com/ceph/ceph-deploy/pull/282 that these changes were no longer needed.