### PR TITLE
allow to skip rpm imports with `cephdeploy.conf`

### DIFF
--- a/ceph_deploy/tests/unit/test_conf.py
+++ b/ceph_deploy/tests/unit/test_conf.py
@@ -1,5 +1,6 @@
 from cStringIO import StringIO
 from textwrap import dedent
+import pytest
 from mock import Mock, patch
 from ceph_deploy import conf
 from ceph_deploy.tests import fakes
@@ -147,6 +148,10 @@ class TestConfGetList(object):
         assert cfg.get_default_repo() is False
 
 
+truthy_values = ['yes', 'true', 'on']
+falsy_values = ['no', 'false', 'off']
+
+
 class TestSetOverrides(object):
 
     def setup(self):
@@ -167,3 +172,21 @@ class TestSetOverrides(object):
         self.conf.items = Mock(return_value=(('bar', 1),))
         arg_obj = conf.cephdeploy.set_overrides(self.args, self.conf)
         assert arg_obj.bar == 1
+
+    @pytest.mark.parametrize('value', truthy_values)
+    def test_override_truthy_values(self, value):
+        self.conf.sections = Mock(
+            return_value=['ceph-deploy-global', 'ceph-deploy-install']
+        )
+        self.conf.items = Mock(return_value=(('bar', value),))
+        arg_obj = conf.cephdeploy.set_overrides(self.args, self.conf)
+        assert arg_obj.bar is True
+
+    @pytest.mark.parametrize('value', falsy_values)
+    def test_override_falsy_values(self, value):
+        self.conf.sections = Mock(
+            return_value=['ceph-deploy-global', 'ceph-deploy-install']
+        )
+        self.conf.items = Mock(return_value=(('bar', value),))
+        arg_obj = conf.cephdeploy.set_overrides(self.args, self.conf)
+        assert arg_obj.bar is False

--- a/docs/source/conf.rst
+++ b/docs/source/conf.rst
@@ -80,6 +80,25 @@ a repository.
 Repositories can be very complex to describe and most of the time (specially
 for yum repositories) they can be very verbose too.
 
+Setting Default Flags or Values
+-------------------------------
+Because the configuration loading allows specifying the same flags as in the
+CLI it is possible to set defaults. For example, assuming that a user always
+wants to install Ceph the following way (that doesn't create/modify remote repo
+files)::
+
+    ceph-deploy install --no-adjust-repos {nodes}
+
+This can be the default behavior by setting it in the right section in the
+configuration file, which should look like this::
+
+    [ceph-deploy-install]
+    adjust_repos = False
+
+The default for ``adjust_repos`` is ``True``, but because we are changing this
+to ``False`` the CLI will now have this behavior changed without the need to
+pass any flag.
+
 Repository Sections
 -------------------
 Keys will depend on the type of package manager that will use it. Certain keys


### PR DESCRIPTION
Setting a default flag in `cephdeploy.conf` flag should work, except that for this specific case, where a boolean flag was needed (vs. a flag with a value) it was not getting parsed correctly.

This PR addresses this problem and documents the example that was needed for the related issue.

Reference ticket: https://bugzilla.redhat.com/show_bug.cgi?id=1219310