### PR TITLE
at runtime, display all flags and values

### DIFF
--- a/ceph_deploy/cli.py
+++ b/ceph_deploy/cli.py
@@ -27,6 +27,14 @@ Full documentation can be found at: http://ceph.com/ceph-deploy/docs
 """ % ceph_deploy.__version__)
 
 
+def log_flags(args, logger=None):
+    logger = logger or LOG
+    logger.info('ceph-deploy options:')
+
+    for k, v in args.__dict__.items():
+        logger.info(' %-30s: %s' % (k, v))
+
+
 def get_parser():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -158,6 +166,7 @@ def _main(args=None, namespace=None):
         ceph_deploy.__version__,
         join(sys.argv, " "))
     )
+    log_flags(args)
 
     return args.func(args)
 

--- a/ceph_deploy/cli.py
+++ b/ceph_deploy/cli.py
@@ -32,6 +32,8 @@ def log_flags(args, logger=None):
     logger.info('ceph-deploy options:')
 
     for k, v in args.__dict__.items():
+        if k.startswith('_'):
+            continue
         logger.info(' %-30s: %s' % (k, v))
 
 

--- a/ceph_deploy/tests/unit/test_cli.py
+++ b/ceph_deploy/tests/unit/test_cli.py
@@ -1,0 +1,46 @@
+from ceph_deploy import cli
+from ceph_deploy.tests import util
+
+
+class FakeLogger(object):
+
+    def __init__(self):
+        self._calls = []
+        self._info = []
+
+    def _output(self):
+        return '\n'.join(self._calls)
+
+    def _record(self, level, message):
+        self._calls.append(message)
+        method = getattr(self, '_%s' % level)
+        method.append(message)
+
+    def info(self, message):
+        self._record('info', message)
+
+
+class TestLogFlags(object):
+
+    def setup(self):
+        self.logger = FakeLogger()
+
+    def test_logs_multiple_object_attributes(self):
+        args = util.Empty(verbose=True, adjust_repos=False)
+        cli.log_flags(args, logger=self.logger)
+        result = self.logger._output()
+        assert ' verbose ' in result
+        assert ' adjust_repos ' in result
+
+    def test_attributes_are_logged_with_values(self):
+        args = util.Empty(verbose=True)
+        cli.log_flags(args, logger=self.logger)
+        result = self.logger._output()
+        assert ' verbose ' in result
+        assert ' : True' in result
+
+    def test_private_attributes_are_not_logged(self):
+        args = util.Empty(verbose=True, _private='some value')
+        cli.log_flags(args, logger=self.logger)
+        result = self.logger._output()
+        assert ' _private ' not in result

--- a/ceph_deploy/tests/util.py
+++ b/ceph_deploy/tests/util.py
@@ -18,4 +18,11 @@ def generate_ips(start_ip, end_ip):
     return ip_range
 
 
-
+class Empty(object):
+    """
+    A bare class, with explicit behavior for key/value items to be set at
+    instantiation.
+    """
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)


### PR DESCRIPTION
Example output:

    (ceph-deploy)papaya-2 ~/tmp/foo ᓆ ceph-deploy new node2
    [ceph_deploy.conf][DEBUG ] found configuration file at: /Users/alfredo/tmp/foo/cephdeploy.conf
    [ceph_deploy.cli][INFO  ] Invoked (1.5.25): /Users/alfredo/.virtualenvs/ceph-deploy/bin/ceph-deploy new node2
    [ceph_deploy.cli][INFO  ] ceph-deploy options:
    [ceph_deploy.cli][INFO  ]  username                      : None
    [ceph_deploy.cli][INFO  ]  func                          : <function new at 0x103e23aa0>
    [ceph_deploy.cli][INFO  ]  verbose                       : True
    [ceph_deploy.cli][INFO  ]  overwrite_conf                : False
    [ceph_deploy.cli][INFO  ]  prog                          : ceph-deploy
    [ceph_deploy.cli][INFO  ]  quiet                         : False
    [ceph_deploy.cli][INFO  ]  cd_conf                       : <ceph_deploy.conf.cephdeploy.Conf instance at 0x103e46098>
    [ceph_deploy.cli][INFO  ]  cluster                       : ceph
    [ceph_deploy.cli][INFO  ]  ssh_copykey                   : True
    [ceph_deploy.cli][INFO  ]  mon                           : ['node2']
    [ceph_deploy.cli][INFO  ]  public_network                : None
    [ceph_deploy.cli][INFO  ]  ceph_conf                     : None
    [ceph_deploy.cli][INFO  ]  bar                           : '1'
    [ceph_deploy.cli][INFO  ]  cluster_network               : None
    [ceph_deploy.cli][INFO  ]  default_release               : False
    [ceph_deploy.cli][INFO  ]  fsid                          : None
    [ceph_deploy.new][DEBUG ] Creating new cluster named ceph
    [ceph_deploy.new][INFO  ] making sure passwordless SSH succeeds
    [node2][DEBUG ] connected to host: papaya-2.local
    [node2][INFO  ] Running command: ssh -CT -o BatchMode=yes node2


Reference issue: http://tracker.ceph.com/issues/11788
