### PR TITLE
Use git.ceph.com for GPG keys

### DIFF
--- a/ceph_deploy/conf/cephdeploy.py
+++ b/ceph_deploy/conf/cephdeploy.py
@@ -37,7 +37,7 @@ cd_conf_template = """
 # enabled=1
 # gpgcheck=1
 # type=rpm-md
-# gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+# gpgkey=https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc
 
 # apt repos:
 # [myrepo]
@@ -48,7 +48,7 @@ cd_conf_template = """
 #
 # [cephrepo]
 # baseurl=http://ceph.com/rpm-emperor/el6/noarch
-# gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+# gpgkey=https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc
 """
 
 

--- a/ceph_deploy/conf/cephdeploy.py
+++ b/ceph_deploy/conf/cephdeploy.py
@@ -4,6 +4,8 @@ import os
 from os import path
 import re
 
+from ceph_deploy.util.paths import gpg
+
 logger = logging.getLogger('ceph_deploy.conf')
 
 cd_conf_template = """
@@ -37,7 +39,7 @@ cd_conf_template = """
 # enabled=1
 # gpgcheck=1
 # type=rpm-md
-# gpgkey=https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc
+# gpgkey={gpgurl}
 
 # apt repos:
 # [myrepo]
@@ -48,8 +50,8 @@ cd_conf_template = """
 #
 # [cephrepo]
 # baseurl=http://ceph.com/rpm-emperor/el6/noarch
-# gpgkey=https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc
-"""
+# gpgkey={gpgurl}
+""".format(gpgurl=gpg.url('release'))
 
 
 def location():

--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -1,6 +1,7 @@
 from ceph_deploy.util import pkg_managers, templates
 from ceph_deploy.lib import remoto
 from ceph_deploy.hosts.util import install_yum_priorities
+from ceph_deploy.util.paths import gpg
 
 
 def rpm_dist(distro):
@@ -63,7 +64,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                 [
                     'rpm',
                     '--import',
-                    "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key)
+                    gpg.url(key)
                 ]
             )
 
@@ -94,7 +95,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                     release=release.split(".", 1)[0],
                     machine=machine,
                     version=version),
-                "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key),
+                gpg.url(key),
                 adjust_repos=True,
                 extra_installs=False
             )

--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -63,7 +63,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                 [
                     'rpm',
                     '--import',
-                    "https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key)
+                    "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key)
                 ]
             )
 
@@ -94,7 +94,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                     release=release.split(".", 1)[0],
                     machine=machine,
                     version=version),
-                "https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key),
+                "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key),
                 adjust_repos=True,
                 extra_installs=False
             )

--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -2,6 +2,7 @@ from urlparse import urlparse
 
 from ceph_deploy.lib import remoto
 from ceph_deploy.util import pkg_managers
+from ceph_deploy.util.paths import gpg
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):
@@ -36,7 +37,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                 'wget',
                 '-O',
                 '{key}.asc'.format(key=key),
-                'https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/{key}.asc'.format(key=key),
+                gpg.url(key),
             ],
             stop_on_nonzero=False,
         )

--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -36,7 +36,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                 'wget',
                 '-O',
                 '{key}.asc'.format(key=key),
-                'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/{key}.asc'.format(key=key),
+                'https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/{key}.asc'.format(key=key),
             ],
             stop_on_nonzero=False,
         )

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -1,6 +1,7 @@
 from ceph_deploy.lib import remoto
 from ceph_deploy.hosts.centos.install import repo_install, mirror_install  # noqa
 from ceph_deploy.hosts.util import install_yum_priorities
+from ceph_deploy.util.paths import gpg
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):
@@ -26,7 +27,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                 [
                     'rpm',
                     '--import',
-                    "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key)
+                    gpg.url(key)
                 ]
             )
 
@@ -64,7 +65,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                     release=release.split(".", 1)[0],
                     machine=machine,
                     version=version),
-                "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key),
+                gpg.url(key),
                 adjust_repos=True,
                 extra_installs=False
             )

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -26,7 +26,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                 [
                     'rpm',
                     '--import',
-                    "https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key)
+                    "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key)
                 ]
             )
 
@@ -64,7 +64,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                     release=release.split(".", 1)[0],
                     machine=machine,
                     version=version),
-                "https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key),
+                "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(key=key),
                 adjust_repos=True,
                 extra_installs=False
             )

--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -40,7 +40,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
             [
                 'rpm',
                 '--import',
-                "{protocol}://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(
+                "{protocol}://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(
                     key=key,
                     protocol=protocol)
             ]

--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -1,5 +1,6 @@
 from ceph_deploy.util import templates, pkg_managers
 from ceph_deploy.lib import remoto
+from ceph_deploy.util.paths import gpg
 import logging
 
 LOG = logging.getLogger(__name__)
@@ -40,9 +41,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
             [
                 'rpm',
                 '--import',
-                "{protocol}://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/{key}.asc".format(
-                    key=key,
-                    protocol=protocol)
+                gpg.url(key, protocol=protocol)
             ]
         )
 

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -6,6 +6,7 @@ from ceph_deploy import hosts
 from ceph_deploy.cliutil import priority
 from ceph_deploy.lib import remoto
 from ceph_deploy.util.constants import default_components
+from ceph_deploy.util.paths import gpg
 
 LOG = logging.getLogger(__name__)
 
@@ -137,7 +138,7 @@ def install(args):
         # custom repo arguments
         repo_url = os.environ.get('CEPH_DEPLOY_REPO_URL') or args.repo_url
         gpg_url = os.environ.get('CEPH_DEPLOY_GPG_URL') or args.gpg_url
-        gpg_fallback = 'https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+        gpg_fallback = gpg.url('release')
 
         if gpg_url is None and repo_url:
             LOG.warning('--gpg-url was not used, will fallback')

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -137,7 +137,7 @@ def install(args):
         # custom repo arguments
         repo_url = os.environ.get('CEPH_DEPLOY_REPO_URL') or args.repo_url
         gpg_url = os.environ.get('CEPH_DEPLOY_GPG_URL') or args.gpg_url
-        gpg_fallback = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+        gpg_fallback = 'https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc'
 
         if gpg_url is None and repo_url:
             LOG.warning('--gpg-url was not used, will fallback')

--- a/ceph_deploy/tests/unit/util/test_paths.py
+++ b/ceph_deploy/tests/unit/util/test_paths.py
@@ -44,3 +44,7 @@ class TestMonPaths(object):
     def test_gpg_url_autobuild(self):
         result = paths.gpg.url('autobuild')
         assert result == "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc"
+
+    def test_gpg_url_http(self):
+        result = paths.gpg.url('release', protocol="http")
+        assert result == "http://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc"

--- a/ceph_deploy/tests/unit/util/test_paths.py
+++ b/ceph_deploy/tests/unit/util/test_paths.py
@@ -36,3 +36,11 @@ class TestMonPaths(object):
         result = paths.mon.monmap('mycluster', 'myhostname')
         assert result.startswith('/')
         assert result.endswith('tmp/mycluster.myhostname.monmap')
+
+    def test_gpg_url_release(self):
+        result = paths.gpg.url('release')
+        assert result == "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc"
+
+    def test_gpg_url_autobuild(self):
+        result = paths.gpg.url('autobuild')
+        assert result == "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc"

--- a/ceph_deploy/util/constants.py
+++ b/ceph_deploy/util/constants.py
@@ -28,3 +28,5 @@ default_components = namedtuple('DefaultComponents', ['rpm', 'deb'])
 # TODO: This needs to get unified once the packaging naming gets consistent
 default_components.rpm = tuple(_base_components + ['ceph-radosgw'])
 default_components.deb = tuple(_base_components + ['radosgw'])
+
+gpg_key_base_url = "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/"

--- a/ceph_deploy/util/constants.py
+++ b/ceph_deploy/util/constants.py
@@ -29,4 +29,4 @@ default_components = namedtuple('DefaultComponents', ['rpm', 'deb'])
 default_components.rpm = tuple(_base_components + ['ceph-radosgw'])
 default_components.deb = tuple(_base_components + ['radosgw'])
 
-gpg_key_base_url = "https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/"
+gpg_key_base_url = "git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/"

--- a/ceph_deploy/util/paths/__init__.py
+++ b/ceph_deploy/util/paths/__init__.py
@@ -1,2 +1,3 @@
 import mon # noqa
 import osd # noqa
+import gpg # noqa

--- a/ceph_deploy/util/paths/gpg.py
+++ b/ceph_deploy/util/paths/gpg.py
@@ -1,4 +1,8 @@
 from ceph_deploy.util import constants
 
-def url(key_type):
-    return "%s%s.asc" % (constants.gpg_key_base_url, key_type)
+def url(key_type, protocol="https"):
+    return "{protocol}://{url}{key_type}.asc".format(
+        protocol=protocol,
+        url=constants.gpg_key_base_url,
+        key_type=key_type
+    )

--- a/ceph_deploy/util/paths/gpg.py
+++ b/ceph_deploy/util/paths/gpg.py
@@ -1,0 +1,4 @@
+from ceph_deploy.util import constants
+
+def url(key_type):
+    return "%s%s.asc" % (constants.gpg_key_base_url, key_type)

--- a/docs/source/conf.rst
+++ b/docs/source/conf.rst
@@ -52,7 +52,7 @@ This is how a default configuration file would look like::
     # enabled=1
     # gpgcheck=1
     # type=rpm-md
-    # gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+    # gpgkey=https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc
 
     # apt repos:
     # [myrepo]
@@ -63,7 +63,7 @@ This is how a default configuration file would look like::
     #
     # [cephrepo]
     # baseurl=http://ceph.com/rpm-emperor/el6/noarch
-    # gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+    # gpgkey=https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc
 
 .. conf_sections:
 
@@ -165,7 +165,7 @@ configuration file demonstrates)::
     enabled=1
     gpgcheck=1
     type=rpm-md
-    gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+    gpgkey=https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc
 
 In this case, the repository called ``myrepo`` defines the ``extra-repos`` key
 with just one extra one: ``cephrepo``.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -133,7 +133,7 @@ trying to compose the right URL for the release being installed.
 It is strongly suggested that both flags be provided. However, the
 ``--gpg-url`` will default to the current one in the ceph repository::
 
-    https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+    https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc
 
 .. versionadded:: 1.3.3
 
@@ -150,7 +150,7 @@ top of the directory that holds the repository files.
 That file is used by Ceph as the key for its signed packages and it is usually
 retrieved from::
 
-        https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+        https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc
 
 This is how it would look the process to get Ceph installed from a local
 repository in an admin host::


### PR DESCRIPTION
Grab the GPG release/autobuild key from git.ceph.com instead of ceph.com/git.

Do some cleanup to make this URL only be defined in one place.

Ref: http://tracker.ceph.com/issues/11406