### PR TITLE
[RM-11572] use http to get GPG key on Wheezy

### DIFF
--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -31,13 +31,17 @@ def install(distro, version_kind, version, adjust_repos, **kw):
     )
 
     if adjust_repos:
+        # Wheezy does not like the git.ceph.com SSL cert
+        protocol = 'https'
+        if codename == 'wheezy':
+            protocol = 'http'
         remoto.process.run(
             distro.conn,
             [
                 'wget',
                 '-O',
                 '{key}.asc'.format(key=key),
-                gpg.url(key),
+                gpg.url(key, protocol=protocol),
             ],
             stop_on_nonzero=False,
         )


### PR DESCRIPTION
For whatever reason, Debian Wheezy will not accept the SSL cert on git.ceph.com, though other distros seem to be fine with it.  So, switch to http for that distro.

Reference: http://tracker.ceph.com/issues/11572