### PR TITLE
Fix package installation on SUSE platforms

### DIFF
--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -6,6 +6,23 @@ import logging
 LOG = logging.getLogger(__name__)
 
 
+def map_components(components):
+    # SUSE distributions don't offer the same granularity of packages as
+    # used by ceph-deploy, so we need to do some mapping.
+    packages = []
+
+    if (('ceph-osd' in components)
+     or ('ceph-mds' in components)
+     or ('ceph-mon' in components)):
+        packages.append('ceph')
+    if 'ceph-common' in components:
+        packages.append('ceph-common')
+    if 'ceph-radosgw' in components:
+        packages.append('ceph-radosgw')
+
+    return packages
+
+
 def install(distro, version_kind, version, adjust_repos, **kw):
     # note: when split packages for ceph land for SUSE,
     # `kw['components']` will have those. Unused for now.

--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -7,93 +7,11 @@ LOG = logging.getLogger(__name__)
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):
-    # note: when split packages for ceph land for Suse,
+    # note: when split packages for ceph land for SUSE,
     # `kw['components']` will have those. Unused for now.
-    release = distro.release
-    machine = distro.machine_type
-
-    if version_kind in ['stable', 'testing']:
-        key = 'release'
-    else:
-        key = 'autobuild'
-
-
-    distro_name = None
-    if distro.codename == 'Mantis':
-        distro_name = 'opensuse12.2'
-
-    if (distro.name == "SUSE Linux Enterprise Server") and (str(distro.release) == "11"):
-        distro_name = 'sles11'
-
-    if distro_name == None:
-        LOG.warning('Untested version of %s: assuming compatible with SUSE Linux Enterprise Server 11', distro.name)
-        distro_name = 'sles11'
-
-
-    if adjust_repos:
-        # Work around code due to bug in SLE 11
-        # https://bugzilla.novell.com/show_bug.cgi?id=875170
-        protocol = "https"
-        if distro_name == 'sles11':
-            protocol = "http"
-        remoto.process.run(
-            distro.conn,
-            [
-                'rpm',
-                '--import',
-                gpg.url(key, protocol=protocol)
-            ]
-        )
-
-        if version_kind == 'stable':
-            url = 'http://ceph.com/rpm-{version}/{distro}/'.format(
-                version=version,
-                distro=distro_name,
-                )
-        elif version_kind == 'testing':
-            url = 'http://ceph.com/rpm-testing/{distro}/'.format(distro=distro_name)
-        elif version_kind == 'dev':
-            url = 'http://gitbuilder.ceph.com/ceph-rpm-{distro}{release}-{machine}-basic/ref/{version}/'.format(
-                distro=distro_name,
-                release=release.split(".", 1)[0],
-                machine=machine,
-                version=version,
-                )
-
-        remoto.process.run(
-            distro.conn,
-            [
-                'rpm',
-                '-Uvh',
-                '--replacepkgs',
-                '--force',
-                '--quiet',
-                '{url}ceph-release-1-0.noarch.rpm'.format(
-                    url=url,
-                    ),
-                ]
-            )
-
-    remoto.process.run(
-        distro.conn,
-        [
-            'zypper',
-            '--non-interactive',
-            'refresh'
-            ],
-        )
-
-    remoto.process.run(
-        distro.conn,
-        [
-            'zypper',
-            '--non-interactive',
-            '--quiet',
-            'install',
-            'ceph',
-            'ceph-radosgw',
-            ],
-        )
+    packages = ['ceph', 'ceph-radosgw']
+    pkg_managers.zypper_refresh(distro.conn)
+    pkg_managers.zypper(distro.conn, packages)
 
 
 def mirror_install(distro, repo_url, gpg_url, adjust_repos, **kw):

--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -15,7 +15,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
 
 
 def mirror_install(distro, repo_url, gpg_url, adjust_repos, **kw):
-    # note: when split packages for ceph land for Suse,
+    # note: when split packages for ceph land for SUSE,
     # `kw['components']` will have those. Unused for now.
     repo_url = repo_url.strip('/')  # Remove trailing slashes
     gpg_url_path = gpg_url.split('file://')[-1]  # Remove file if present
@@ -37,25 +37,9 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos, **kw):
         distro.conn.remote_module.write_file(
             '/etc/zypp/repos.d/ceph.repo',
             ceph_repo_content)
-        remoto.process.run(
-            distro.conn,
-            [
-                'zypper',
-                '--non-interactive',
-                'refresh'
-            ]
-        )
+        pkg_managers.zypper_refresh(distro.conn)
 
-    remoto.process.run(
-        distro.conn,
-        [
-            'zypper',
-            '--non-interactive',
-            '--quiet',
-            'install',
-            'ceph',
-            ],
-        )
+    pkg_managers.zypper(distro.conn, 'ceph')
 
 
 def repo_install(distro, reponame, baseurl, gpgkey, **kw):

--- a/ceph_deploy/hosts/suse/uninstall.py
+++ b/ceph_deploy/hosts/suse/uninstall.py
@@ -4,6 +4,7 @@ from ceph_deploy.lib import remoto
 def uninstall(conn, purge=False):
     packages = [
         'ceph',
+        'ceph-common',
         'libcephfs1',
         'librados2',
         'librbd1',

--- a/ceph_deploy/hosts/suse/uninstall.py
+++ b/ceph_deploy/hosts/suse/uninstall.py
@@ -1,3 +1,4 @@
+from ceph_deploy.util import pkg_managers
 from ceph_deploy.lib import remoto
 
 
@@ -10,12 +11,4 @@ def uninstall(conn, purge=False):
         'librbd1',
         'ceph-radosgw',
         ]
-    cmd = [
-        'zypper',
-        '--non-interactive',
-        '--quiet',
-        'remove',
-        ]
-
-    cmd.extend(packages)
-    remoto.process.run(conn, cmd)
+    pkg_managers.zypper_remove(conn, packages)

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -164,3 +164,16 @@ def zypper_remove(conn, packages, *a, **kw):
         *a,
         **kw
     )
+
+
+def zypper_refresh(conn):
+    cmd = [
+        'zypper',
+        '--non-interactive',
+        'refresh',
+        ]
+
+    return remoto.process.run(
+        conn,
+        cmd
+    )


### PR DESCRIPTION
As raised:
http://article.gmane.org/gmane.comp.file-systems.ceph.devel/25511

This change set implements option (2), where install() triggers the installation of packages from existing (distribution) repositories.

Component based installation is also fixed, through the use of a component->package name mapping function.