### PR TITLE
Use argparse subparsers when subcommands have their own subcommands

### DIFF
--- a/ceph_deploy/calamari.py
+++ b/ceph_deploy/calamari.py
@@ -84,21 +84,19 @@ def make(parser):
     Calamari packages is already configured. Refer to the docs for examples
     (http://ceph.com/ceph-deploy/docs/conf.html)
     """
-    parser.add_argument(
-        'subcommand',
-        choices=[
-            'connect',
-            ],
-        )
+    calamari_parser = parser.add_subparsers(dest='subcommand')
 
-    parser.add_argument(
+    calamari_connect = calamari_parser.add_parser(
+        'connect',
+        help='Configure host(s) to connect to Calamari master'
+    )
+    calamari_connect.add_argument(
         '--master',
         nargs='?',
         metavar='MASTER SERVER',
         help="The domain for the Calamari master server"
     )
-
-    parser.add_argument(
+    calamari_connect.add_argument(
         'hosts',
         nargs='+',
     )

--- a/ceph_deploy/config.py
+++ b/ceph_deploy/config.py
@@ -82,20 +82,28 @@ def make(parser):
     """
     Push configuration file to a remote host.
     """
-    parser.add_argument(
-        'subcommand',
-        metavar='SUBCOMMAND',
-        choices=[
-            'push',
-            'pull',
-            ],
-        help='push or pull',
+    config_parser = parser.add_subparsers(dest='subcommand')
+
+    config_push = config_parser.add_parser(
+        'push',
+        help='push Ceph config file to one or more remote hosts'
         )
-    parser.add_argument(
+    config_push.add_argument(
         'client',
         metavar='HOST',
         nargs='*',
-        help='host to push/pull the config to/from',
+        help='host(s) to push the config file to',
+        )
+
+    config_pull = config_parser.add_parser(
+        'pull',
+        help='pull Ceph config file from one or more remote hosts'
+        )
+    config_pull.add_argument(
+        'client',
+        metavar='HOST',
+        nargs='*',
+        help='host(s) to pull the config file from',
         )
     parser.set_defaults(
         func=config,

--- a/ceph_deploy/mds.py
+++ b/ceph_deploy/mds.py
@@ -209,17 +209,15 @@ def colon_separated(s):
 @priority(30)
 def make(parser):
     """
-    Deploy ceph MDS on remote hosts.
+    Ceph MDS daemon management
     """
-    parser.add_argument(
-        'subcommand',
-        metavar='SUBCOMMAND',
-        choices=[
-            'create',
-            ],
-        help='create an MDS',
-        )
-    parser.add_argument(
+    mds_parser = parser.add_subparsers(dest='subcommand')
+
+    mds_create = mds_parser.add_parser(
+        'create',
+        help='Deploy Ceph MDS on remote host(s)'
+    )
+    mds_create.add_argument(
         'mds',
         metavar='HOST[:NAME]',
         nargs='*',

--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -494,30 +494,50 @@ def make(parser):
     parser.formatter_class = argparse.RawDescriptionHelpFormatter
     parser.description = sub_command_help
 
-    parser.add_argument(
-        'subcommand',
-        choices=[
-            'add',
-            'create',
-            'create-initial',
-            'destroy',
-            ],
-        )
+    mon_parser = parser.add_subparsers(dest='subcommand')
 
-    parser.add_argument(
+    mon_add = mon_parser.add_parser(
+            'add',
+            help='Add a new Ceph MON to an existing cluster'
+    )
+    mon_add.add_argument(
         '--address',
         nargs='?',
-        dest='address',
+    )
+    mon_add.add_argument(
+        'mon',
+        nargs='*',
     )
 
-    parser.add_argument(
+    mon_create = mon_parser.add_parser(
+            'create',
+            help='Deploy new Ceph MON(s) as part of creating a new cluster'
+    )
+    mon_create.add_argument(
         '--keyrings',
         nargs='?',
-        dest='keyrings',
+        help='concatenate multiple keyrings to be seeded on new monitors',
+    )
+    mon_create.add_argument(
+        'mon',
+        nargs='*',
+    )
+
+    mon_create_initial = mon_parser.add_parser(
+        'create-initial',
+        help='Deploy new Ceph MON(s) from ceph.conf and ensure quorum'
+    )
+    mon_create_initial.add_argument(
+        '--keyrings',
+        nargs='?',
         help='concatenate multiple keyrings to be seeded on new monitors',
     )
 
-    parser.add_argument(
+    mon_destroy = mon_parser.add_parser(
+        'destroy',
+        help='Completely remove Ceph MON from remote host(s)'
+    )
+    mon_destroy.add_argument(
         'mon',
         nargs='*',
     )

--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -1,13 +1,12 @@
-import argparse
 import json
 import logging
 import re
 import os
-from textwrap import dedent
 import time
 
 from ceph_deploy import conf, exc, admin
 from ceph_deploy.cliutil import priority
+from ceph_deploy.util.help_formatters import ToggleRawTextHelpFormatter
 from ceph_deploy.util import paths, net, files
 from ceph_deploy.lib import remoto
 from ceph_deploy.new import new_mon_keyring
@@ -454,51 +453,21 @@ def mon(args):
 @priority(30)
 def make(parser):
     """
-    Deploy ceph monitor on remote hosts.
+    Ceph MON Daemon management
     """
-    sub_command_help = dedent("""
-    Subcommands:
-
-    create-initial
-      Will deploy for monitors defined in `mon initial members`, wait until
-      they form quorum and then gatherkeys, reporting the monitor status along
-      the process. If monitors don't form quorum the command will eventually
-      time out.
-
-    create
-      Deploy monitors by specifying them like:
-
-        ceph-deploy mon create node1 node2 node3
-
-      If no hosts are passed it will default to use the `mon initial members`
-      defined in the configuration.
-
-    add
-      Add a monitor to an existing cluster:
-
-        ceph-deploy mon add node1
-
-      Or:
-
-        ceph-deploy mon add node1 --address 192.168.1.10
-
-      If the section for the monitor exists and defines a `mon addr` that
-      will be used, otherwise it will fallback by resolving the hostname to an
-      IP. If `--address` is used it will override all other options. Please
-      note that only one node can be added at a time.
-
-    destroy
-      Completely remove monitors on a remote host. Requires hostname(s) as
-      arguments.
-    """)
-    parser.formatter_class = argparse.RawDescriptionHelpFormatter
-    parser.description = sub_command_help
+    parser.formatter_class = ToggleRawTextHelpFormatter
 
     mon_parser = parser.add_subparsers(dest='subcommand')
 
     mon_add = mon_parser.add_parser(
-            'add',
-            help='Add a new Ceph MON to an existing cluster'
+        'add',
+        help=('R|Add a monitor to an existing cluster:\n'
+              '\tceph-deploy mon add node1\n'
+              'Or:\n'
+              '\tceph-deploy mon add --address 192.168.1.10 node1\n'
+              'If the section for the monitor exists and defines a `mon addr` that\n'
+              'will be used, otherwise it will fallback by resolving the hostname to an\n'
+              'IP. If `--address` is used it will override all other options.')
     )
     mon_add.add_argument(
         '--address',
@@ -510,8 +479,11 @@ def make(parser):
     )
 
     mon_create = mon_parser.add_parser(
-            'create',
-            help='Deploy new Ceph MON(s) as part of creating a new cluster'
+        'create',
+        help=('R|Deploy monitors by specifying them like:\n'
+              '\tceph-deploy mon create node1 node2 node3\n'
+              'If no hosts are passed it will default to use the\n'
+              '`mon initial members` defined in the configuration.')
     )
     mon_create.add_argument(
         '--keyrings',
@@ -525,7 +497,10 @@ def make(parser):
 
     mon_create_initial = mon_parser.add_parser(
         'create-initial',
-        help='Deploy new Ceph MON(s) from ceph.conf and ensure quorum'
+        help=('Will deploy for monitors defined in `mon initial members`, '
+              'wait until they form quorum and then gatherkeys, reporting '
+              'the monitor status along the process. If monitors don\'t form '
+              'quorum the command will eventually time out.')
     )
     mon_create_initial.add_argument(
         '--keyrings',

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -208,9 +208,6 @@ def prepare_disk(
     if zap:
         args.append('--zap-disk')
     if fs_type:
-        if fs_type not in ('btrfs', 'ext4', 'xfs'):
-            raise argparse.ArgumentTypeError(
-                "FS_TYPE must be one of 'btrfs', 'ext4' or 'xfs'")
         args.extend(['--fs-type', fs_type])
     if dmcrypt:
         args.append('--dmcrypt')

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -207,8 +207,6 @@ def prepare_disk(
         ]
     if zap:
         args.append('--zap-disk')
-    if fs_type:
-        args.extend(['--fs-type', fs_type])
     if dmcrypt:
         args.append('--dmcrypt')
         if dmcrypt_dir is not None:
@@ -217,6 +215,8 @@ def prepare_disk(
     args.extend([
         '--cluster',
         cluster,
+        '--fs-type',
+        fs_type,
         '--',
         disk,
     ])

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -767,45 +767,80 @@ def make_disk(parser):
     """
     Manage disks on a remote host.
     """
-    parser.add_argument(
-        'subcommand',
-        metavar='SUBCOMMAND',
-        choices=[
-            'list',
-            'prepare',
-            'activate',
-            'zap',
-            ],
-        help='list, prepare, activate, zap',
+    disk_parser = parser.add_subparsers(dest='subcommand')
+
+    disk_zap = disk_parser.add_parser(
+        'zap',
+        help='destroy existing partition table and content for DISK',
         )
-    parser.add_argument(
+    disk_zap.add_argument(
         'disk',
         nargs='+',
         metavar='HOST:DISK',
         type=colon_separated,
-        help='host and disk (or path)',
+        help='host and disk'
         )
-    parser.add_argument(
+
+    disk_list = disk_parser.add_parser(
+        'list',
+        help='List disk info from remote host(s)'
+        )
+    disk_list.add_argument(
+        'disk',
+        nargs='+',
+        metavar='HOST:DISK',
+        type=colon_separated,
+        help='remote host to list OSDs from'
+        )
+
+    disk_prepare = disk_parser.add_parser(
+        'prepare',
+        help='Prepare a disk for use as Ceph OSD by formatting/partitioning disk'
+        )
+    disk_prepare.add_argument(
         '--zap-disk',
         action='store_true', default=None,
         help='destroy existing partition table and content for DISK',
         )
-    parser.add_argument(
+    disk_prepare.add_argument(
         '--fs-type',
         metavar='FS_TYPE',
+        choices=['xfs',
+                 'ext4',
+                 'btrfs'
+                 ],
         default='xfs',
-        help='filesystem to use to format DISK (xfs, btrfs or ext4)'
+        help='filesystem to use to format DISK (xfs, btrfs, or ext4)',
         )
-    parser.add_argument(
+    disk_prepare.add_argument(
         '--dmcrypt',
         action='store_true', default=None,
         help='use dm-crypt on DISK',
         )
-    parser.add_argument(
+    disk_prepare.add_argument(
         '--dmcrypt-key-dir',
         metavar='KEYDIR',
         default='/etc/ceph/dmcrypt-keys',
         help='directory where dm-crypt keys are stored',
+        )
+    disk_prepare.add_argument(
+        'disk',
+        nargs='+',
+        metavar='HOST:DISK',
+        type=colon_separated,
+        help='host and disk to prepare',
+        )
+
+    disk_activate = disk_parser.add_parser(
+        'activate',
+        help='Start (activate) Ceph OSD from disk that was previously prepared'
+        )
+    disk_activate.add_argument(
+        'disk',
+        nargs='+',
+        metavar='HOST:DISK',
+        type=colon_separated,
+        help='host and disk to activate',
         )
     parser.set_defaults(
         func=disk,

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -656,45 +656,106 @@ def make(parser):
     parser.formatter_class = argparse.RawDescriptionHelpFormatter
     parser.description = sub_command_help
 
-    parser.add_argument(
-        'subcommand',
-        metavar='SUBCOMMAND',
-        choices=[
-            'list',
-            'create',
-            'prepare',
-            'activate',
-            ],
-        help='list, create (prepare+activate), prepare, or activate',
+    osd_parser = parser.add_subparsers(dest='subcommand')
+
+    osd_list = osd_parser.add_parser(
+        'list',
+        help='List OSD info from remote host(s)'
         )
-    parser.add_argument(
+    osd_list.add_argument(
+        'disk',
+        nargs='+',
+        metavar='HOST:DISK[:JOURNAL]',
+        type=colon_separated,
+        help='remote host to list OSDs from'
+        )
+
+    osd_create = osd_parser.add_parser(
+        'create',
+        help='Create new Ceph OSD daemon by preparing and activating disk'
+        )
+    osd_create.add_argument(
+        '--zap-disk',
+        action='store_true', default=None,
+        help='destroy existing partition table and content for DISK',
+        )
+    osd_create.add_argument(
+        '--fs-type',
+        metavar='FS_TYPE',
+        choices=['xfs',
+                 'ext4',
+                 'btrfs'
+                 ],
+        default='xfs',
+        help='filesystem to use to format DISK (xfs, btrfs, or ext4)',
+        )
+    osd_create.add_argument(
+        '--dmcrypt',
+        action='store_true', default=None,
+        help='use dm-crypt on DISK',
+        )
+    osd_create.add_argument(
+        '--dmcrypt-key-dir',
+        metavar='KEYDIR',
+        default='/etc/ceph/dmcrypt-keys',
+        help='directory where dm-crypt keys are stored',
+        )
+    osd_create.add_argument(
         'disk',
         nargs='+',
         metavar='HOST:DISK[:JOURNAL]',
         type=colon_separated,
         help='host and disk to prepare',
         )
-    parser.add_argument(
+
+    osd_prepare = osd_parser.add_parser(
+        'prepare',
+        help='Prepare a disk for use as Ceph OSD by formatting/partitioning disk'
+        )
+    osd_prepare.add_argument(
         '--zap-disk',
         action='store_true', default=None,
         help='destroy existing partition table and content for DISK',
         )
-    parser.add_argument(
+    osd_prepare.add_argument(
         '--fs-type',
         metavar='FS_TYPE',
+        choices=['xfs',
+                 'ext4',
+                 'btrfs'
+                 ],
         default='xfs',
-        help='filesystem to use to format DISK (xfs, btrfs or ext4)',
+        help='filesystem to use to format DISK (xfs, btrfs, or ext4)',
         )
-    parser.add_argument(
+    osd_prepare.add_argument(
         '--dmcrypt',
         action='store_true', default=None,
         help='use dm-crypt on DISK',
         )
-    parser.add_argument(
+    osd_prepare.add_argument(
         '--dmcrypt-key-dir',
         metavar='KEYDIR',
         default='/etc/ceph/dmcrypt-keys',
         help='directory where dm-crypt keys are stored',
+        )
+    osd_prepare.add_argument(
+        'disk',
+        nargs='+',
+        metavar='HOST:DISK[:JOURNAL]',
+        type=colon_separated,
+        help='host and disk to prepare',
+        )
+
+    osd_activate = osd_parser.add_parser(
+        'activate',
+        help='Start (activate) Ceph OSD from disk that was previously prepared'
+        )
+    osd_activate.add_argument(
+        'disk',
+        nargs='+',
+        metavar='HOST:DISK[:JOURNAL]',
+        type=colon_separated,
+        help='host and disk to activate',
         )
     parser.set_defaults(
         func=osd,

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -185,17 +185,14 @@ def colon_separated(s):
 @priority(30)
 def make(parser):
     """
-    Deploy ceph RGW on remote hosts.
+    Ceph RGW daemon management
     """
-    parser.add_argument(
-        'subcommand',
-        metavar='SUBCOMMAND',
-        choices=[
-            'create',
-            ],
-        help='create an RGW instance',
+    rgw_parser = parser.add_subparsers(dest='subcommand')
+    rgw_create = rgw_parser.add_parser(
+        'create',
+        help='Create an RGW instance'
         )
-    parser.add_argument(
+    rgw_create.add_argument(
         'rgw',
         metavar='HOST[:NAME]',
         nargs='*',

--- a/ceph_deploy/tests/parser/test_calamari.py
+++ b/ceph_deploy/tests/parser/test_calamari.py
@@ -16,6 +16,14 @@ class TestParserCalamari(object):
         assert 'positional arguments:' in out
         assert 'optional arguments:' in out
 
+    def test_calamari_connect_help(self, capsys):
+        with pytest.raises(SystemExit):
+            self.parser.parse_args('calamari connect --help'.split())
+        out, err = capsys.readouterr()
+        assert 'usage: ceph-deploy calamari connect' in out
+        assert 'positional arguments:' in out
+        assert 'optional arguments:' in out
+
     def test_calamari_connect_host_required(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('calamari connect'.split())

--- a/ceph_deploy/tests/parser/test_disk.py
+++ b/ceph_deploy/tests/parser/test_disk.py
@@ -28,7 +28,6 @@ class TestParserDisk(object):
         out, err = capsys.readouterr()
         assert 'invalid choice' in err
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_disk_list_help(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('disk list --help'.split())
@@ -52,7 +51,6 @@ class TestParserDisk(object):
         hosts = [x[0] for x in args.disk]
         assert hosts == hostnames
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_disk_prepare_help(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('disk prepare --help'.split())
@@ -76,7 +74,6 @@ class TestParserDisk(object):
         args = self.parser.parse_args('disk prepare --fs-type ext4 host1:sdb'.split())
         assert args.fs_type == "ext4"
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_disk_prepare_fstype_invalid(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('disk prepare --fs-type bork host1:sdb'.split())
@@ -117,7 +114,6 @@ class TestParserDisk(object):
         hosts = [x[0] for x in args.disk]
         assert hosts == hostnames
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_disk_activate_help(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('disk activate --help'.split())
@@ -141,7 +137,6 @@ class TestParserDisk(object):
         hosts = [x[0] for x in args.disk]
         assert hosts == hostnames
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_disk_zap_help(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('disk zap --help'.split())

--- a/ceph_deploy/tests/parser/test_mon.py
+++ b/ceph_deploy/tests/parser/test_mon.py
@@ -38,7 +38,6 @@ class TestParserMON(object):
         out, err = capsys.readouterr()
         assert 'invalid choice' in err
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_mon_create_initial_help(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('mon create-initial --help'.split())
@@ -53,12 +52,10 @@ class TestParserMON(object):
         args = self.parser.parse_args('mon create-initial --keyrings /tmp/keys'.split())
         assert args.keyrings == "/tmp/keys"
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_mon_create_initial_keyrings_host_raises_err(self):
         with pytest.raises(SystemExit):
             self.parser.parse_args('mon create-initial test1'.split())
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_mon_create_help(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('mon create --help'.split())
@@ -82,7 +79,6 @@ class TestParserMON(object):
         args = self.parser.parse_args('mon create'.split() + hosts)
         assert args.mon == hosts
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_mon_add_help(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('mon add --help'.split())
@@ -97,7 +93,7 @@ class TestParserMON(object):
         args = self.parser.parse_args('mon add test1 --address 10.10.0.1'.split())
         assert args.address == '10.10.0.1'
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
+    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12150")
     def test_mon_add_no_host_raises_err(self):
         with pytest.raises(SystemExit):
             self.parser.parse_args('mon add'.split())
@@ -106,19 +102,18 @@ class TestParserMON(object):
         args = self.parser.parse_args('mon add test1'.split())
         assert args.mon == ["test1"]
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
+    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12150")
     def test_mon_add_multi_host_raises_err(self):
         with pytest.raises(SystemExit):
             self.parser.parse_args('mon add test1 test2'.split())
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_mon_destroy_help(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('mon destroy --help'.split())
         out, err = capsys.readouterr()
         assert 'usage: ceph-deploy mon destroy' in out
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
+    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12150")
     def test_mon_destroy_no_host_raises_err(self):
         with pytest.raises(SystemExit):
             self.parser.parse_args('mon destroy'.split())

--- a/ceph_deploy/tests/parser/test_osd.py
+++ b/ceph_deploy/tests/parser/test_osd.py
@@ -28,7 +28,6 @@ class TestParserOSD(object):
         out, err = capsys.readouterr()
         assert 'invalid choice' in err
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_osd_list_help(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('osd list --help'.split())
@@ -52,7 +51,6 @@ class TestParserOSD(object):
         hosts = [x[0] for x in args.disk]
         assert hosts == hostnames
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_osd_create_help(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('osd create --help'.split())
@@ -93,7 +91,6 @@ class TestParserOSD(object):
         args = self.parser.parse_args('osd create --fs-type ext4 host1:sdb'.split())
         assert args.fs_type == "ext4"
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_osd_create_fstype_invalid(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('osd create --fs-type bork host1:sdb'.split())
@@ -117,7 +114,6 @@ class TestParserOSD(object):
         args = self.parser.parse_args('osd create --dmcrypt --dmcrypt-key-dir /tmp/keys host1:sdb'.split())
         assert args.dmcrypt_key_dir == "/tmp/keys"
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_osd_prepare_help(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('osd prepare --help'.split())
@@ -141,7 +137,6 @@ class TestParserOSD(object):
         args = self.parser.parse_args('osd prepare --fs-type ext4 host1:sdb'.split())
         assert args.fs_type == "ext4"
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_osd_prepare_fstype_invalid(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('osd prepare --fs-type bork host1:sdb'.split())
@@ -182,7 +177,6 @@ class TestParserOSD(object):
         hosts = [x[0] for x in args.disk]
         assert hosts == hostnames
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12151")
     def test_osd_activate_help(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('osd activate --help'.split())

--- a/ceph_deploy/util/help_formatters.py
+++ b/ceph_deploy/util/help_formatters.py
@@ -2,9 +2,31 @@ import argparse
 
 
 class ToggleRawTextHelpFormatter(argparse.HelpFormatter):
-    """Inspired by the SmartFormatter at
-       https://bitbucket.org/ruamel/std.argparse
-   """
+    """ArgParse help formatter that allows raw text in individual help strings
+
+        Inspired by the SmartFormatter at
+           https://bitbucket.org/ruamel/std.argparse
+
+       Normally to include newlines in the help output of argparse, you have
+       use argparse.RawDescriptionHelpFormatter. But this means raw text is enabled
+       everywhere, and not just for specific help entries where you might need it.
+
+       This help formatter allows for you to optional enable/toggle raw text on
+       individual menu items by prefixing the help string with 'R|'.
+
+       Example:
+
+       parser.formatter_class = ToggleRawTextHelpFormatter
+       parser.add_argument('--verbose', action=store_true,
+                           help='Enable verbose mode')
+       #Above help is formatted just as default argparse.HelpFormatter
+
+       parser.add_argument('--complex-arg', action=store_true,
+                           help=('R|This help description use '
+                                 'newlines and tabs and they will be preserved in'
+                                 'the help output.\n\n'
+                                 '\tHow cool is that?'))
+    """
     def _split_lines(self, text, width):
         if text.startswith('R|'):
             return text[2:].splitlines()  

--- a/ceph_deploy/util/help_formatters.py
+++ b/ceph_deploy/util/help_formatters.py
@@ -1,0 +1,11 @@
+import argparse
+
+
+class ToggleRawTextHelpFormatter(argparse.HelpFormatter):
+    """Inspired by the SmartFormatter at
+       https://bitbucket.org/ruamel/std.argparse
+   """
+    def _split_lines(self, text, width):
+        if text.startswith('R|'):
+            return text[2:].splitlines()  
+        return argparse.HelpFormatter._split_lines(self, text, width)


### PR DESCRIPTION
This patchset changes the argparse config to use more subparsers to have much better help output and only list CLI options that are relevant to a given subcommand.  This may be best demonstrated by example.  Let's look at the `mon` subcommand.

`mon --help` before:

```
$ ceph-deploy mon --help
usage: ceph-deploy mon [-h] [--address [ADDRESS]] [--keyrings [KEYRINGS]]
                       {add,create,create-initial,destroy} [mon [mon ...]]

Subcommands:

create-initial
  Will deploy for monitors defined in `mon initial members`, wait until
  they form quorum and then gatherkeys, reporting the monitor status along
  the process. If monitors don't form quorum the command will eventually
  time out.

create
  Deploy monitors by specifying them like:

    ceph-deploy mon create node1 node2 node3

  If no hosts are passed it will default to use the `mon initial members`
  defined in the configuration.

add
  Add a monitor to an existing cluster:

    ceph-deploy mon add node1

  Or:

    ceph-deploy mon add node1 --address 192.168.1.10

  If the section for the monitor exists and defines a `mon addr` that
  will be used, otherwise it will fallback by resolving the hostname to an
  IP. If `--address` is used it will override all other options. Please
  note that only one node can be added at a time.

destroy
  Completely remove monitors on a remote host. Requires hostname(s) as
  arguments.

positional arguments:
  {add,create,create-initial,destroy}
  mon

optional arguments:
  -h, --help            show this help message and exit
  --address [ADDRESS]
  --keyrings [KEYRINGS]
                        concatenate multiple keyrings to be seeded on new
                        monitors
```
Besides being so long that users probably don't read it all, it's also misleading because it lists options at the top-level that do not apply to all subcommands, like `--keyrings` and `--address`.

`mon --help` after:
```
$ ceph-deploy mon --help
usage: ceph-deploy mon [-h] {add,create,create-initial,destroy} ...

Ceph MON Daemon management

positional arguments:
  {add,create,create-initial,destroy}
    add                 Add a monitor to an existing cluster:
                        	ceph-deploy mon add node1
                        Or:
                        	ceph-deploy mon add --address 192.168.1.10 node1
                        If the section for the monitor exists and defines a `mon addr` that
                        will be used, otherwise it will fallback by resolving the hostname to an
                        IP. If `--address` is used it will override all other options.
    create              Deploy monitors by specifying them like:
                        	ceph-deploy mon create node1 node2 node3
                        If no hosts are passed it will default to use the
                        `mon initial members` defined in the configuration.
    create-initial      Will deploy for monitors defined in `mon initial
                        members`, wait until they form quorum and then
                        gatherkeys, reporting the monitor status along the
                        process. If monitors don't form quorum the command
                        will eventually time out.
    destroy             Completely remove Ceph MON from remote host(s)

optional arguments:
  -h, --help            show this help message and exit
```

`mon add --help` before:
```
$ ceph-deploy mon add --help
usage: ceph-deploy mon [-h] [--address [ADDRESS]] [--keyrings [KEYRINGS]]
                       {add,create,create-initial,destroy} [mon [mon ...]]

Subcommands:

create-initial
  Will deploy for monitors defined in `mon initial members`, wait until
  they form quorum and then gatherkeys, reporting the monitor status along
  the process. If monitors don't form quorum the command will eventually
  time out.

create
  Deploy monitors by specifying them like:

    ceph-deploy mon create node1 node2 node3

  If no hosts are passed it will default to use the `mon initial members`
  defined in the configuration.

add
  Add a monitor to an existing cluster:

    ceph-deploy mon add node1

  Or:

    ceph-deploy mon add node1 --address 192.168.1.10

  If the section for the monitor exists and defines a `mon addr` that
  will be used, otherwise it will fallback by resolving the hostname to an
  IP. If `--address` is used it will override all other options. Please
  note that only one node can be added at a time.

destroy
  Completely remove monitors on a remote host. Requires hostname(s) as
  arguments.

positional arguments:
  {add,create,create-initial,destroy}
  mon

optional arguments:
  -h, --help            show this help message and exit
  --address [ADDRESS]
  --keyrings [KEYRINGS]
                        concatenate multiple keyrings to be seeded on new
                        monitors
```
I always found this difficult, as using `mon add --help` does not provide any new information about the `add` subcommand.  It just prints the same help as `mon --help`, including help for other subcommands and irrelevant options.

`mon add --help` after:
```
$ ceph-deploy mon add --help
usage: ceph-deploy mon add [-h] [--address [ADDRESS]] [mon [mon ...]]

positional arguments:
  mon

optional arguments:
  -h, --help           show this help message and exit
  --address [ADDRESS]
```

Now we are showing the user only the options that are relevant to the command they asked for help on.

The subcommands that got modified in this patchset are:
- calamari
- osd
- disk
- config
- mds
- mon
- rgw

I tried hard to make only one type of change here -- adding the subparsers.  There are other things that need to be fixed, but I purposely left them broken because they are covered under other open issues.