### PR TITLE
Set owner of directory and keyrings according to owner of /var/lib/ceph.

### DIFF
--- a/ceph_deploy/tests/test_cli_admin.py
+++ b/ceph_deploy/tests/test_cli_admin.py
@@ -44,7 +44,7 @@ def test_write_keyring(tmpdir):
 
     distro = MagicMock()
     distro.conn = MagicMock()
-    remotes.write_file.func_defaults = (str(tmpdir),)
+    remotes.write_file.func_defaults = (0644, str(tmpdir), -1, -1)
     distro.conn.remote_module = remotes
     distro.conn.remote_module.write_conf = Mock()
 


### PR DESCRIPTION
If Ceph is running under separate ceph user, it requires access
to various files under this user.
This patch tries to set owner of these files to the current owner
of base_dir (/var/lib/ceph).

If the ceph directory is owned by root, it expects old installation
and should work with old tools as well (avoids --setuser option).

Signed-off-by: Milan Broz <mbroz@redhat.com>