### PR TITLE
mon: support for installing on debian using systemd

### DIFF
--- a/ceph_deploy/hosts/debian/__init__.py
+++ b/ceph_deploy/hosts/debian/__init__.py
@@ -2,6 +2,7 @@ import mon  # noqa
 import pkg  # noqa
 from install import install, mirror_install, repo_install  # noqa
 from uninstall import uninstall  # noqa
+from ceph_deploy.util import system
 
 # Allow to set some information about this distro
 #
@@ -9,6 +10,7 @@ from uninstall import uninstall  # noqa
 distro = None
 release = None
 codename = None
+conn = None
 
 def choose_init():    
     """
@@ -16,6 +18,11 @@ def choose_init():
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
+
+    if system.is_systemd(conn):
+        return 'systemd'
+
     if distro.lower() == 'ubuntu':
         return 'upstart'
+
     return 'sysvinit'


### PR DESCRIPTION
This was executed when starting the mon service:
Running command: /usr/sbin/service ceph -c /etc/ceph/ceph.conf start mon.cephmon

Which spawns these processes (systemctl status):
├─run-26687.service
│ ├─26688 /bin/bash -c ulimit -n 32768; /usr/bin/ceph-mon -i cephmon --pid-file /var/run/ceph/mon.cephmon.pid -c /etc/ceph/ceph.conf --cluster ceph -f
│ └─26691 /usr/bin/ceph-mon -i cephmon --pid-file /var/run/ceph/mon.cephmon.pid -c /etc/ceph/ceph.conf --cluster ceph -f

After a reboot the ceph-mon service won't be started.

When systemd is installed the ceph-mon service needs to be enabled and started
using systemctl instead. The "systemctl enable" command will create a symlink
in /etc/systemd/system/multi-user.target.wants/ceph-mon.service which will
start the ceph-mon service on boot.
