### PR TITLE
Enforce proper number of hosts on CLI

### DIFF
--- a/ceph_deploy/config.py
+++ b/ceph_deploy/config.py
@@ -91,7 +91,7 @@ def make(parser):
     config_push.add_argument(
         'client',
         metavar='HOST',
-        nargs='*',
+        nargs='+',
         help='host(s) to push the config file to',
         )
 
@@ -102,7 +102,7 @@ def make(parser):
     config_pull.add_argument(
         'client',
         metavar='HOST',
-        nargs='*',
+        nargs='+',
         help='host(s) to pull the config file from',
         )
     parser.set_defaults(

--- a/ceph_deploy/config.py
+++ b/ceph_deploy/config.py
@@ -80,7 +80,7 @@ def config(args):
 @priority(70)
 def make(parser):
     """
-    Push configuration file to a remote host.
+    Copy ceph.conf to/from remote host(s)
     """
     config_parser = parser.add_subparsers(dest='subcommand')
 

--- a/ceph_deploy/mds.py
+++ b/ceph_deploy/mds.py
@@ -131,9 +131,6 @@ def mds_create(args):
         ' '.join(':'.join(x or '' for x in t) for t in args.mds),
         )
 
-    if not args.mds:
-        raise exc.NeedHostError()
-
     key = get_bootstrap_mds_key(cluster=args.cluster)
 
     bootstrapped = set()
@@ -220,7 +217,7 @@ def make(parser):
     mds_create.add_argument(
         'mds',
         metavar='HOST[:NAME]',
-        nargs='*',
+        nargs='+',
         type=colon_separated,
         help='host (and optionally the daemon name) to deploy on',
         )

--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -172,10 +172,7 @@ def concatenate_keyrings(args):
 def mon_add(args):
     cfg = conf.ceph.load(args)
 
-    if not args.mon:
-        raise exc.NeedHostError()
-    elif len(args.mon) > 1:
-        raise exc.GenericError('Only one node can be added at a time')
+    # args.mon is a list with only one entry
     mon_host = args.mon[0]
 
     try:
@@ -475,7 +472,7 @@ def make(parser):
     )
     mon_add.add_argument(
         'mon',
-        nargs='*',
+        nargs=1,
     )
 
     mon_create = mon_parser.add_parser(

--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -185,7 +185,7 @@ def mon_add(args):
         )
 
     LOG.info('ensuring configuration of new mon host: %s', mon_host)
-    args.client = [mon_host]
+    args.client = args.mon
     admin.admin(args)
     LOG.debug(
         'Adding mon to cluster %s, host %s',

--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -511,7 +511,7 @@ def make(parser):
     )
     mon_destroy.add_argument(
         'mon',
-        nargs='*',
+        nargs='+',
     )
 
     parser.set_defaults(

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -118,9 +118,6 @@ def rgw_create(args):
         ' '.join(':'.join(x or '' for x in t) for t in args.rgw),
         )
 
-    if not args.rgw:
-        raise exc.NeedHostError()
-
     key = get_bootstrap_rgw_key(cluster=args.cluster)
 
     bootstrapped = set()
@@ -195,7 +192,7 @@ def make(parser):
     rgw_create.add_argument(
         'rgw',
         metavar='HOST[:NAME]',
-        nargs='*',
+        nargs='+',
         type=colon_separated,
         help='host (and optionally the daemon name) to deploy on. \
                 NAME is automatically prefixed with \'rgw.\'',

--- a/ceph_deploy/tests/parser/test_config.py
+++ b/ceph_deploy/tests/parser/test_config.py
@@ -28,7 +28,6 @@ class TestParserConfig(object):
         out, err = capsys.readouterr()
         assert 'invalid choice' in err
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12150")
     def test_config_push_host_required(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('config push'.split())
@@ -44,7 +43,6 @@ class TestParserConfig(object):
         args = self.parser.parse_args('config push'.split() + hostnames)
         assert args.client == hostnames
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12150")
     def test_config_pull_host_required(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('config pull'.split())

--- a/ceph_deploy/tests/parser/test_mds.py
+++ b/ceph_deploy/tests/parser/test_mds.py
@@ -16,7 +16,6 @@ class TestParserMDS(object):
         assert 'positional arguments:' in out
         assert 'optional arguments:' in out
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12150")
     def test_mds_create_host_required(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('mds create'.split())

--- a/ceph_deploy/tests/parser/test_mon.py
+++ b/ceph_deploy/tests/parser/test_mon.py
@@ -2,7 +2,7 @@ import pytest
 
 from ceph_deploy.cli import get_parser
 
-SUBCMDS_WITH_ARGS = ['add', 'destroy']
+SUBCMDS_WITH_ARGS = ['add', 'destroy', 'create']
 SUBCMDS_WITHOUT_ARGS = ['create', 'create-initial']
 
 
@@ -19,18 +19,15 @@ class TestParserMON(object):
         assert 'positional arguments:' in out
         assert 'optional arguments:' in out
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12150")
     @pytest.mark.parametrize('cmd', SUBCMDS_WITH_ARGS)
     def test_mon_valid_subcommands_with_args(self, cmd, capsys):
-        with pytest.raises(SystemExit):
-            self.parser.parse_args(['mon'] + ['%s' % cmd] + ['host1'])
-        out, err = capsys.readouterr()
-        assert 'too few arguments' in err
-        assert 'invalid choice' not in err
+        args = self.parser.parse_args(['mon'] + ['%s' % cmd] + ['host1'])
+        assert args.subcommand == cmd
 
     @pytest.mark.parametrize('cmd', SUBCMDS_WITHOUT_ARGS)
     def test_mon_valid_subcommands_without_args(self, cmd, capsys):
-        self.parser.parse_args(['mon'] + ['%s' % cmd])
+        args = self.parser.parse_args(['mon'] + ['%s' % cmd])
+        assert args.subcommand == cmd
 
     def test_mon_invalid_subcommand(self, capsys):
         with pytest.raises(SystemExit):
@@ -111,7 +108,6 @@ class TestParserMON(object):
         out, err = capsys.readouterr()
         assert 'usage: ceph-deploy mon destroy' in out
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12150")
     def test_mon_destroy_no_host_raises_err(self):
         with pytest.raises(SystemExit):
             self.parser.parse_args('mon destroy'.split())

--- a/ceph_deploy/tests/parser/test_mon.py
+++ b/ceph_deploy/tests/parser/test_mon.py
@@ -93,7 +93,6 @@ class TestParserMON(object):
         args = self.parser.parse_args('mon add test1 --address 10.10.0.1'.split())
         assert args.address == '10.10.0.1'
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12150")
     def test_mon_add_no_host_raises_err(self):
         with pytest.raises(SystemExit):
             self.parser.parse_args('mon add'.split())
@@ -102,7 +101,6 @@ class TestParserMON(object):
         args = self.parser.parse_args('mon add test1'.split())
         assert args.mon == ["test1"]
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12150")
     def test_mon_add_multi_host_raises_err(self):
         with pytest.raises(SystemExit):
             self.parser.parse_args('mon add test1 test2'.split())

--- a/ceph_deploy/tests/parser/test_rgw.py
+++ b/ceph_deploy/tests/parser/test_rgw.py
@@ -16,7 +16,6 @@ class TestParserRGW(object):
         assert 'positional arguments:' in out
         assert 'optional arguments:' in out
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12150")
     def test_rgw_create_host_required(self, capsys):
         with pytest.raises(SystemExit):
             self.parser.parse_args('rgw create'.split())


### PR DESCRIPTION
When we require one or more hosts on the CLI, use `nargs='+'`.

For `mon add` we only allow 1 host, so use `nargs=1`.  This preserves the existing behavior of having the hostnames be in a list.

Remove code that checked for this after argument parsing, leave the enforcement to argparse itself (which is now validated through our unit tests).

http://tracker.ceph.com/issues/12150