### PR TITLE
[RM-12168] Don't use store_true and default=None

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -673,7 +673,7 @@ def make(parser):
         )
     osd_create.add_argument(
         '--zap-disk',
-        action='store_true', default=None,
+        action='store_true',
         help='destroy existing partition table and content for DISK',
         )
     osd_create.add_argument(
@@ -688,7 +688,7 @@ def make(parser):
         )
     osd_create.add_argument(
         '--dmcrypt',
-        action='store_true', default=None,
+        action='store_true',
         help='use dm-crypt on DISK',
         )
     osd_create.add_argument(
@@ -711,7 +711,7 @@ def make(parser):
         )
     osd_prepare.add_argument(
         '--zap-disk',
-        action='store_true', default=None,
+        action='store_true',
         help='destroy existing partition table and content for DISK',
         )
     osd_prepare.add_argument(
@@ -726,7 +726,7 @@ def make(parser):
         )
     osd_prepare.add_argument(
         '--dmcrypt',
-        action='store_true', default=None,
+        action='store_true',
         help='use dm-crypt on DISK',
         )
     osd_prepare.add_argument(
@@ -796,7 +796,7 @@ def make_disk(parser):
         )
     disk_prepare.add_argument(
         '--zap-disk',
-        action='store_true', default=None,
+        action='store_true',
         help='destroy existing partition table and content for DISK',
         )
     disk_prepare.add_argument(
@@ -811,7 +811,7 @@ def make_disk(parser):
         )
     disk_prepare.add_argument(
         '--dmcrypt',
-        action='store_true', default=None,
+        action='store_true',
         help='use dm-crypt on DISK',
         )
     disk_prepare.add_argument(

--- a/ceph_deploy/tests/parser/test_disk.py
+++ b/ceph_deploy/tests/parser/test_disk.py
@@ -57,7 +57,6 @@ class TestParserDisk(object):
         out, err = capsys.readouterr()
         assert 'usage: ceph-deploy disk prepare' in out
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12168")
     def test_disk_prepare_zap_default_false(self):
         args = self.parser.parse_args('disk prepare host1:sdb'.split())
         assert args.zap_disk is False
@@ -80,7 +79,6 @@ class TestParserDisk(object):
         out, err = capsys.readouterr()
         assert 'invalid choice' in err
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12168")
     def test_disk_prepare_dmcrypt_default_false(self):
         args = self.parser.parse_args('disk prepare host1:sdb'.split())
         assert args.dmcrypt is False

--- a/ceph_deploy/tests/parser/test_osd.py
+++ b/ceph_deploy/tests/parser/test_osd.py
@@ -74,7 +74,6 @@ class TestParserOSD(object):
         hosts = [x[0] for x in args.disk]
         assert hosts == hostnames
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12168")
     def test_osd_create_zap_default_false(self):
         args = self.parser.parse_args('osd create host1:sdb'.split())
         assert args.zap_disk is False
@@ -97,7 +96,6 @@ class TestParserOSD(object):
         out, err = capsys.readouterr()
         assert 'invalid choice' in err
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12168")
     def test_osd_create_dmcrypt_default_false(self):
         args = self.parser.parse_args('osd create host1:sdb'.split())
         assert args.dmcrypt is False
@@ -120,7 +118,6 @@ class TestParserOSD(object):
         out, err = capsys.readouterr()
         assert 'usage: ceph-deploy osd prepare' in out
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12168")
     def test_osd_prepare_zap_default_false(self):
         args = self.parser.parse_args('osd prepare host1:sdb'.split())
         assert args.zap_disk is False
@@ -143,7 +140,6 @@ class TestParserOSD(object):
         out, err = capsys.readouterr()
         assert 'invalid choice' in err
 
-    @pytest.mark.skipif(reason="http://tracker.ceph.com/issues/12168")
     def test_osd_prepare_dmcrypt_default_false(self):
         args = self.parser.parse_args('osd prepare host1:sdb'.split())
         assert args.dmcrypt is False


### PR DESCRIPTION
http://tracker.ceph.com/issues/12168

Not sure why this was ever seen as necessary.  With the store_true
action, it will be False if not present, True if passed on the CLI.

We just need to the boolean value, and there is no need to set
the flag to None instead of False when it is not present.