### PR TITLE
Support iSCSI utility installation (targetcli) v2

### DIFF
--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -18,6 +18,8 @@ def map_components(components):
         packages.append('ceph-common')
     if 'ceph-radosgw' in components:
         packages.append('ceph-radosgw')
+    if 'targetcli' in components:
+        packages.append('targetcli')
 
     return packages
 

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -185,8 +185,11 @@ def install(args):
                 components=components,
             )
 
-        # Check the ceph version we just installed
-        hosts.common.ceph_version(distro.conn)
+        # If ceph was installed, then log the version
+        if (('ceph-osd' in components)
+         or ('ceph-mds' in components)
+         or ('ceph-mon' in components)):
+            hosts.common.ceph_version(distro.conn)
         distro.conn.exit()
 
 

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -56,6 +56,7 @@ def detect_components(args, distro):
         'install_mds': 'ceph-mds',
         'install_mon': 'ceph-mon',
         'install_common': 'ceph-common',
+        'install_iscsi': 'targetcli',
     }
 
     if distro.is_rpm:
@@ -526,6 +527,13 @@ def make(parser):
         dest='install_all',
         action='store_true',
         help='install all ceph components (e.g. mon,osd,mds,rgw). This is the default',
+    )
+
+    parser.add_argument(
+        '--iscsi',
+        dest='install_iscsi',
+        action='store_true',
+        help='install the LIO iSCSI target utility only',
     )
 
     repo = parser.add_mutually_exclusive_group()

--- a/ceph_deploy/tests/test_install.py
+++ b/ceph_deploy/tests/test_install.py
@@ -48,6 +48,7 @@ class TestDetectComponents(object):
         self.args.install_mon = False
         self.args.install_osd = False
         self.args.install_rgw = False
+        self.args.install_iscsi = False
         self.args.install_common = False
         self.args.repo = False
         self.distro = Mock()
@@ -111,3 +112,8 @@ class TestDetectComponents(object):
         assert result == sorted([
             'ceph-osd', 'ceph-mds', 'ceph-mon', 'ceph-radosgw'
         ])
+
+    def test_install_only_iscsi(self):
+        self.args.install_iscsi = True
+        result = install.detect_components(self.args, self.distro)
+        assert result == ['targetcli']


### PR DESCRIPTION
This series adds support for iSCSI component installation, in preparation for clustered RBD/LIO iSCSI target deployment:
https://wiki.ceph.com/Planning/Blueprints/Hammer/Clustered_SCSI_target_using_RBD

Changes since v1 (https://github.com/ceph/ceph-deploy/pull/309)
- Added test_install_only_iscsi unit test
- Rebased against master