### PR TITLE
[BZ-1228842] Echo RGW default port during rgw create

### DIFF
--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -155,6 +155,12 @@ def rgw_create(args):
 
             create_rgw(distro, name, args.cluster, distro.init)
             distro.conn.exit()
+            LOG.info(
+                ('The Ceph Object Gateway (RGW) is now running on host %s and '
+                 'default port %s'),
+                hostname,
+                '7480'
+            )
         except RuntimeError as e:
             LOG.error(e)
             errors += 1


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1228842

Let the user know the default port has been used for RGW, as the
default port is probably not one people will guess.

We just hardcode the port number for now, since ceph-deploy doesn't allow the user to change the port number when deploying RGW.

Signed-off-by: Travis Rhoden <trhoden@redhat.com>