### PR TITLE
[RM-12374] Pass mon host list from ceph.conf to mon_create

### DIFF
--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -395,6 +395,7 @@ def mon_create_initial(args):
     mon_initial_members = get_mon_initial_members(args, error_on_empty=True)
 
     # create them normally through mon_create
+    args.mon = mon_initial_members
     mon_create(args)
 
     # make the sets to be able to compare late


### PR DESCRIPTION
http://tracker.ceph.com/issues/12374

When using mon_create_initial(), we already have list of initial mon
members from the config file.  Pass it to mon_create() in args.mon
so that mon_create() does not throw an exception when it finds that
args.mon does not exist.

This is actually an optimization as well. mon_create_initial() always
looked up mon_initial_members from the config file, but didn't pass that
to mon_create().  mon_create() would then see that args.mon was empty
and then look up mon_initial_members *again*.  Now we only need to open
and read the file once.

Fixes: #12374

Signed-off-by: Travis Rhoden <trhoden@redhat.com>