### PR TITLE
Class-based package managers to add DNF support for Fedora 22

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -69,6 +69,8 @@ def get(hostname,
     module.conn = conn
     module.machine_type = machine_type
     module.init = module.choose_init()
+    if module.normalized_name in ['fedora']:
+        module.packager = module.get_packager(module)
     return module
 
 

--- a/ceph_deploy/hosts/centos/uninstall.py
+++ b/ceph_deploy/hosts/centos/uninstall.py
@@ -1,7 +1,7 @@
 from ceph_deploy.util import pkg_managers
 
 
-def uninstall(conn, purge=False):
+def uninstall(distro, purge=False):
     packages = [
         'ceph',
         'ceph-release',
@@ -10,8 +10,8 @@ def uninstall(conn, purge=False):
         ]
 
     pkg_managers.yum_remove(
-        conn,
+        distro.conn,
         packages,
     )
 
-    pkg_managers.yum_clean(conn)
+    pkg_managers.yum_clean(distro.conn)

--- a/ceph_deploy/hosts/debian/uninstall.py
+++ b/ceph_deploy/hosts/debian/uninstall.py
@@ -1,7 +1,7 @@
 from ceph_deploy.util import pkg_managers
 
 
-def uninstall(conn, purge=False):
+def uninstall(distro, purge=False):
     packages = [
         'ceph',
         'ceph-mds',
@@ -10,7 +10,7 @@ def uninstall(conn, purge=False):
         'radosgw',
         ]
     pkg_managers.apt_remove(
-        conn,
+        distro.conn,
         packages,
         purge=purge,
     )

--- a/ceph_deploy/hosts/fedora/__init__.py
+++ b/ceph_deploy/hosts/fedora/__init__.py
@@ -3,6 +3,7 @@ from ceph_deploy.hosts.centos import pkg  # noqa
 from ceph_deploy.hosts.centos.install import repo_install  # noqa
 from install import install, mirror_install  # noqa
 from uninstall import uninstall  # noqa
+from ceph_deploy.util import pkg_managers
 
 # Allow to set some information about this distro
 #
@@ -18,3 +19,10 @@ def choose_init():
     Returns the name of a init system (upstart, sysvinit ...).
     """
     return 'sysvinit'
+
+
+def get_packager(module):
+    if module.normalized_release.int_major >= 22:
+        return pkg_managers.DNF(module)
+    else:
+        return pkg_managers.Yum(module)

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -1,6 +1,5 @@
 from ceph_deploy.lib import remoto
 from ceph_deploy.hosts.centos.install import repo_install, mirror_install  # noqa
-from ceph_deploy.hosts.util import install_yum_priorities
 from ceph_deploy.util.paths import gpg
 from ceph_deploy.util import pkg_managers
 
@@ -23,7 +22,8 @@ def install(distro, version_kind, version, adjust_repos, **kw):
         key = 'autobuild'
 
     if adjust_repos:
-        install_yum_priorities(distro)
+        packager.install_priorities_plugin()
+        # haven't been able to determine necessity of check_obsoletes with DNF
         distro.conn.remote_module.enable_yum_priority_obsoletes()
         logger.warning('check_obsoletes has been enabled for Yum priorities plugin')
 

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -1,7 +1,6 @@
 from ceph_deploy.lib import remoto
 from ceph_deploy.hosts.centos.install import repo_install, mirror_install  # noqa
 from ceph_deploy.util.paths import gpg
-from ceph_deploy.util import pkg_managers
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):
@@ -11,18 +10,13 @@ def install(distro, version_kind, version, adjust_repos, **kw):
     release = distro.release
     machine = distro.machine_type
 
-    if distro.normalized_release.int_major >= 22:
-        packager = pkg_managers.DNF(distro)
-    else:
-        packager = pkg_managers.Yum(distro)
-
     if version_kind in ['stable', 'testing']:
         key = 'release'
     else:
         key = 'autobuild'
 
     if adjust_repos:
-        packager.install_priorities_plugin()
+        distro.packager.install_priorities_plugin()
         # haven't been able to determine necessity of check_obsoletes with DNF
         distro.conn.remote_module.enable_yum_priority_obsoletes()
         logger.warning('check_obsoletes has been enabled for Yum priorities plugin')
@@ -81,7 +75,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
         distro.conn.remote_module.set_repo_priority(['Ceph', 'Ceph-noarch', 'ceph-source'])
         logger.warning('altered ceph.repo priorities to contain: priority=1')
 
-    packager.install(
+    distro.packager.install(
         [
             'ceph',
             'ceph-radosgw'

--- a/ceph_deploy/hosts/fedora/uninstall.py
+++ b/ceph_deploy/hosts/fedora/uninstall.py
@@ -1,6 +1,3 @@
-from ceph_deploy.util import pkg_managers
-
-
 def uninstall(distro, purge=False):
     packages = [
         'ceph',
@@ -8,8 +5,4 @@ def uninstall(distro, purge=False):
         'ceph-radosgw',
         ]
 
-    pkg_managers.yum_remove(
-        distro.conn,
-        packages,
-    )
-
+    distro.packager.remove(packages)

--- a/ceph_deploy/hosts/fedora/uninstall.py
+++ b/ceph_deploy/hosts/fedora/uninstall.py
@@ -1,7 +1,7 @@
 from ceph_deploy.util import pkg_managers
 
 
-def uninstall(conn, purge=False):
+def uninstall(distro, purge=False):
     packages = [
         'ceph',
         'ceph-common',
@@ -9,7 +9,7 @@ def uninstall(conn, purge=False):
         ]
 
     pkg_managers.yum_remove(
-        conn,
+        distro.conn,
         packages,
     )
 

--- a/ceph_deploy/hosts/rhel/uninstall.py
+++ b/ceph_deploy/hosts/rhel/uninstall.py
@@ -1,7 +1,7 @@
 from ceph_deploy.util import pkg_managers
 
 
-def uninstall(conn, purge=False):
+def uninstall(distro, purge=False):
     packages = [
         'ceph',
         'ceph-common',
@@ -11,8 +11,8 @@ def uninstall(conn, purge=False):
         ]
 
     pkg_managers.yum_remove(
-        conn,
+        distro.conn,
         packages,
     )
 
-    pkg_managers.yum_clean(conn)
+    pkg_managers.yum_clean(distro.conn)

--- a/ceph_deploy/hosts/suse/uninstall.py
+++ b/ceph_deploy/hosts/suse/uninstall.py
@@ -1,7 +1,7 @@
 from ceph_deploy.util import pkg_managers
 
 
-def uninstall(conn, purge=False):
+def uninstall(distro, purge=False):
     packages = [
         'ceph',
         'ceph-common',
@@ -10,4 +10,4 @@ def uninstall(conn, purge=False):
         'librbd1',
         'ceph-radosgw',
         ]
-    pkg_managers.zypper_remove(conn, packages)
+    pkg_managers.zypper_remove(distro.conn, packages)

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -312,7 +312,7 @@ def uninstall(args):
         LOG.info('Distro info: %s %s %s', distro.name, distro.release, distro.codename)
         rlogger = logging.getLogger(hostname)
         rlogger.info('uninstalling ceph on %s' % hostname)
-        distro.uninstall(distro.conn)
+        distro.uninstall(distro)
         distro.conn.exit()
 
 
@@ -337,7 +337,7 @@ def purge(args):
         LOG.info('Distro info: %s %s %s', distro.name, distro.release, distro.codename)
         rlogger = logging.getLogger(hostname)
         rlogger.info('purging host ... %s' % hostname)
-        distro.uninstall(distro.conn, purge=True)
+        distro.uninstall(distro, purge=True)
         distro.conn.exit()
 
 


### PR DESCRIPTION
This PR does two things:

(1) uses DNF as the package manager for Fedora >= 22
(2) Introduces Yum and DNF package manager classes

The new package manager classes can be instantiated at the time of a call to hosts.get(), with the module only needing to decide once which manager is the correct one.  I've only added this to Fedora right now, as an early adopter of the new code.

I would like to use this everywhere, and think it makes the code a lot cleaner.

Specifically for this change, Fedora installs are a bit weird because F22 packages are only available from the gitbuilders, so you have to do "ceph-deploy install --dev master <HOST>" to try it out.  Becuase it's a dev install, it actually uses centos.mirror_install() :disappointed: to write out a .repo file, so you will still see some references to Yum until  that is abstracted out in a different way.

The other thing that was not clear to me for DNF is that right now we require the Yum priorities plugin.  DNF supports repo priorities natively, so we don't need that with DNF (I have that).  However, we *also* need to configure the priorities plugin with `check_obsoletes=1`, and I couldn't find anything about if there is an equivalent setting in DNF (what it is, where it would be set).

http://tracker.ceph.com/issues/12259