### PR TITLE
More help/argparse cleanup

### DIFF
--- a/ceph_deploy/admin.py
+++ b/ceph_deploy/admin.py
@@ -59,7 +59,7 @@ def make(parser):
         'client',
         metavar='HOST',
         nargs='+',
-        help='host to configure for ceph administration',
+        help='host to configure for Ceph administration',
         )
     parser.set_defaults(
         func=admin,

--- a/ceph_deploy/cli.py
+++ b/ceph_deploy/cli.py
@@ -98,9 +98,6 @@ def get_parser():
             description=fn.__doc__,
             help=fn.__doc__,
             )
-        # ugly kludge but i really want to have a nice way to access
-        # the program name, with subcommand, later
-        p.set_defaults(prog=p.prog)
         if not os.environ.get('CEPH_DEPLOY_TEST'):
             p.set_defaults(cd_conf=ceph_deploy.conf.cephdeploy.load())
 
@@ -108,8 +105,6 @@ def get_parser():
         p.set_defaults(default_release=False)
         fn(p)
     parser.set_defaults(
-        # we want to hold on to this, for later
-        prog=parser.prog,
         cluster='ceph',
         )
 

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -31,7 +31,7 @@ def sanitize_args(args):
 
 def detect_components(args, distro):
     """
-    Since the package split, now there are various different ceph components to
+    Since the package split, now there are various different Ceph components to
     install like:
 
     * ceph
@@ -131,7 +131,7 @@ def install(args):
             continue
 
         rlogger = logging.getLogger(hostname)
-        rlogger.info('installing ceph on %s' % hostname)
+        rlogger.info('installing Ceph on %s' % hostname)
 
         cd_conf = getattr(args, 'cd_conf', None)
 
@@ -264,7 +264,7 @@ def custom_repo(distro, args, cd_conf, rlogger, install_ceph=None):
 def install_repo(args):
     """
     For a user that only wants to install the repository only (and avoid
-    installing ceph and its dependencies).
+    installing Ceph and its dependencies).
     """
     cd_conf = getattr(args, 'cd_conf', None)
 
@@ -273,7 +273,7 @@ def install_repo(args):
         distro = hosts.get(
             hostname,
             username=args.username,
-            # XXX this should get removed once ceph packages are split for
+            # XXX this should get removed once Ceph packages are split for
             # upstream. If default_release is True, it means that the user is
             # trying to install on a RHEL machine and should expect to get RHEL
             # packages. Otherwise, it will need to specify either a specific
@@ -311,7 +311,7 @@ def uninstall(args):
             use_rhceph=True)
         LOG.info('Distro info: %s %s %s', distro.name, distro.release, distro.codename)
         rlogger = logging.getLogger(hostname)
-        rlogger.info('uninstalling ceph on %s' % hostname)
+        rlogger.info('uninstalling Ceph on %s' % hostname)
         distro.uninstall(distro)
         distro.conn.exit()
 
@@ -357,8 +357,8 @@ def purgedata(args):
         distro.conn.exit()
 
     if installed_hosts:
-        LOG.error("ceph is still installed on: %s", installed_hosts)
-        raise RuntimeError("refusing to purge data while ceph is still installed")
+        LOG.error("Ceph is still installed on: %s", installed_hosts)
+        raise RuntimeError("refusing to purge data while Ceph is still installed")
 
     for hostname in args.host:
         distro = hosts.get(hostname, username=args.username)
@@ -525,7 +525,7 @@ def make(parser):
         '--all',
         dest='install_all',
         action='store_true',
-        help='install all ceph components (e.g. mon,osd,mds,rgw). This is the default',
+        help='install all Ceph components (e.g. mon,osd,mds,rgw). This is the default',
     )
 
     repo = parser.add_mutually_exclusive_group()
@@ -573,7 +573,7 @@ def make(parser):
         '--repo-url',
         nargs='?',
         dest='repo_url',
-        help='specify a repo URL that mirrors/contains ceph packages',
+        help='specify a repo URL that mirrors/contains Ceph packages',
     )
 
     parser.add_argument(

--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -526,7 +526,7 @@ def make(parser):
 
 def get_mon_initial_members(args, error_on_empty=False, _cfg=None):
     """
-    Read the ceph config file and return the value of mon_initial_members
+    Read the Ceph config file and return the value of mon_initial_members
     Optionally, a NeedHostError can be raised if the value is None.
     """
     if _cfg:

--- a/ceph_deploy/new.py
+++ b/ceph_deploy/new.py
@@ -116,7 +116,7 @@ def get_public_network_ip(ips, public_subnet):
 
 def new(args):
     if args.ceph_conf:
-        raise RuntimeError('will not create a ceph conf file if attemtping to re-use with `--ceph-conf` flag')
+        raise RuntimeError('will not create a Ceph conf file if attemtping to re-use with `--ceph-conf` flag')
     LOG.debug('Creating new cluster named %s', args.cluster)
     cfg = conf.ceph.CephConf()
     cfg.add_section('global')


### PR DESCRIPTION
Most of what I had intended to under http://tracker.ceph.com/issues/12083 got split out into different issues and have already been resolved (Yay!).

This is just a couple of minor things that I had queued up that didn't go in yet.

The `prog` variable in the argparse namespace always confused me.  It's called out as an "ugly kludge", but it's not actually used anywhere.  Kill it!