### PR TITLE
Only install requested packages for Debian, CentOS, Fedora

### DIFF
--- a/ceph_deploy/hosts/common.py
+++ b/ceph_deploy/hosts/common.py
@@ -178,3 +178,23 @@ def mon_add(distro, args, monitor_keyring):
             args.address,
         ],
     )
+
+
+def map_components(notsplit_packages, components):
+    """
+    Returns a list of packages to install based on component names
+
+    This is done by checking if a component is in notsplit_packages,
+    if it is, we know we need to install 'ceph' instead of the
+    raw component name.  Essentially, this component hasn't been
+    'split' from the master 'ceph' package yet.
+    """
+    packages = set()
+
+    for c in components:
+        if c in notsplit_packages:
+            packages.add('ceph')
+        else:
+            packages.add(c)
+
+    return list(packages)

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -1,11 +1,17 @@
 from ceph_deploy.lib import remoto
 from ceph_deploy.hosts.centos.install import repo_install, mirror_install  # noqa
 from ceph_deploy.util.paths import gpg
+from ceph_deploy.hosts.common import map_components
+
+
+NON_SPLIT_PACKAGES = ['ceph-osd', 'ceph-mon', 'ceph-mds']
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):
-    # note: when split packages for ceph land for Fedora,
-    # `kw['components']` will have those. Unused for now.
+    packages = map_components(
+        NON_SPLIT_PACKAGES,
+        kw.pop('components', [])
+    )
     logger = distro.conn.logger
     release = distro.release
     machine = distro.machine_type
@@ -76,8 +82,5 @@ def install(distro, version_kind, version, adjust_repos, **kw):
         logger.warning('altered ceph.repo priorities to contain: priority=1')
 
     distro.packager.install(
-        [
-            'ceph',
-            'ceph-radosgw'
-        ]
+        packages
     )

--- a/ceph_deploy/tests/unit/hosts/test_common.py
+++ b/ceph_deploy/tests/unit/hosts/test_common.py
@@ -1,0 +1,24 @@
+from ceph_deploy.hosts.common import map_components
+
+
+class TestMapComponents(object):
+
+    def test_map_components_all_split(self):
+        components = ['ceph-mon', 'ceph-osd']
+        packages = map_components([], components)
+        assert set(packages) == set(components)
+
+    def test_map_components_mds_not_split(self):
+        components = ['ceph-mon', 'ceph-osd', 'ceph-mds']
+        packages = map_components(['ceph-mds'], components)
+        assert set(packages) == set(['ceph-mon', 'ceph-osd', 'ceph'])
+
+    def test_map_components_no_duplicates(self):
+        components = ['ceph-mon', 'ceph-osd', 'ceph-mds']
+        packages = map_components(['ceph-mds', 'ceph-osd'], components)
+        assert set(packages) == set(['ceph-mon', 'ceph'])
+        assert len(packages) == len(set(['ceph-mon', 'ceph']))
+
+    def test_map_components_no_components(self):
+        packages = map_components(['ceph-mon'], [])
+        assert len(packages) == 0

--- a/ceph_deploy/tests/unit/hosts/test_suse.py
+++ b/ceph_deploy/tests/unit/hosts/test_suse.py
@@ -1,5 +1,5 @@
 from ceph_deploy.hosts import suse 
-from ceph_deploy.hosts.suse.install import map_components
+from ceph_deploy.hosts.suse.install import map_components, NON_SPLIT_PACKAGES
 
 class TestSuseInit(object):
     def setup(self):
@@ -27,13 +27,8 @@ class TestSuseInit(object):
 
 class TestSuseMapComponents(object):
     def test_valid(self):
-        pkgs = map_components(['ceph-osd', 'ceph-common', 'ceph-radosgw'])
+        pkgs = map_components(NON_SPLIT_PACKAGES, ['ceph-osd', 'ceph-common', 'ceph-radosgw'])
         assert 'ceph' in pkgs
         assert 'ceph-common' in pkgs
         assert 'ceph-radosgw' in pkgs
         assert 'ceph-osd' not in pkgs
-
-    def test_invalid(self):
-        pkgs = map_components(['not-provided', 'ceph-mon'])
-        assert 'not-provided' not in pkgs
-        assert 'ceph' in pkgs


### PR DESCRIPTION
http://tracker.ceph.com/issues/12543

This PR makes it such that `install --rgw` only installs radosgw, `--cli` only installs ceph-common, etc.

This does preserve backwards-compatibility. The default is still "everything", where everything is MON, OSD, MDS, and RGW.  This just makes it such that if a user requests specific daemons, we install the minimal set of packages that can satisfy the request.

That set of packages can be different depending on OS.  For example, debian packages have a separate `ceph-mds` package (enabling it to be installed by itself), but EL/RPM packages do not.

I tested that this didn't break anything by running this sequence of commands on Trusty, CentOS 7, and Fedora 22:

```
ceph-deploy install --cli <node>
ceph-deploy install --rgw <node>
ceph-deploy install --mon --osd <node>
ceph-deploy install --mds <node>
ceph-deploy install <node>
ceph-deploy install --dev master <node>
ceph-deploy install --dev master --rgw <node>
```

Except for on Fedora, I could only test with ``--dev master`` since there are only F22 packages on gitbuilder.

In each case, I looked at the top-level packages listed by Yum/Apt/DNF to see it was the expected set.  All looked good!