### PR TITLE
Use package manager classes for remaining distros

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -69,7 +69,7 @@ def get(hostname,
     module.conn = conn
     module.machine_type = machine_type
     module.init = module.choose_init()
-    if module.normalized_name in ['fedora', 'centos']:
+    if module.normalized_name in ['fedora', 'centos', 'redhat']:
         module.packager = module.get_packager(module)
     return module
 

--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -69,7 +69,7 @@ def get(hostname,
     module.conn = conn
     module.machine_type = machine_type
     module.init = module.choose_init()
-    if module.normalized_name in ['fedora']:
+    if module.normalized_name in ['fedora', 'centos']:
         module.packager = module.get_packager(module)
     return module
 

--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -69,9 +69,7 @@ def get(hostname,
     module.conn = conn
     module.machine_type = machine_type
     module.init = module.choose_init()
-    if module.normalized_name in ['fedora', 'centos', 'redhat',
-                                  'ubuntu', 'debian']:
-        module.packager = module.get_packager(module)
+    module.packager = module.get_packager(module)
     return module
 
 

--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -69,7 +69,8 @@ def get(hostname,
     module.conn = conn
     module.machine_type = machine_type
     module.init = module.choose_init()
-    if module.normalized_name in ['fedora', 'centos', 'redhat']:
+    if module.normalized_name in ['fedora', 'centos', 'redhat',
+                                  'ubuntu', 'debian']:
         module.packager = module.get_packager(module)
     return module
 

--- a/ceph_deploy/hosts/centos/__init__.py
+++ b/ceph_deploy/hosts/centos/__init__.py
@@ -2,6 +2,7 @@ import mon  # noqa
 import pkg  # noqa
 from install import install, mirror_install, repo_install, repository_url_part, rpm_dist  # noqa
 from uninstall import uninstall  # noqa
+from ceph_deploy.util import pkg_managers
 
 # Allow to set some information about this distro
 #
@@ -10,6 +11,7 @@ distro = None
 release = None
 codename = None
 
+
 def choose_init():    
     """
     Select a init system
@@ -17,3 +19,7 @@ def choose_init():
     Returns the name of a init system (upstart, sysvinit ...).
     """
     return 'sysvinit'
+
+
+def get_packager(module):
+    return pkg_managers.Yum(module)

--- a/ceph_deploy/hosts/centos/uninstall.py
+++ b/ceph_deploy/hosts/centos/uninstall.py
@@ -1,6 +1,3 @@
-from ceph_deploy.util import pkg_managers
-
-
 def uninstall(distro, purge=False):
     packages = [
         'ceph',
@@ -9,9 +6,5 @@ def uninstall(distro, purge=False):
         'ceph-radosgw',
         ]
 
-    pkg_managers.yum_remove(
-        distro.conn,
-        packages,
-    )
-
-    pkg_managers.yum_clean(distro.conn)
+    distro.packager.remove(packages)
+    distro.packager.clean()

--- a/ceph_deploy/hosts/debian/__init__.py
+++ b/ceph_deploy/hosts/debian/__init__.py
@@ -2,6 +2,7 @@ import mon  # noqa
 import pkg  # noqa
 from install import install, mirror_install, repo_install  # noqa
 from uninstall import uninstall  # noqa
+from ceph_deploy.util import pkg_managers
 
 # Allow to set some information about this distro
 #
@@ -19,3 +20,7 @@ def choose_init():
     if distro.lower() == 'ubuntu':
         return 'upstart'
     return 'sysvinit'
+
+
+def get_packager(module):
+    return pkg_managers.Apt(module)

--- a/ceph_deploy/hosts/debian/uninstall.py
+++ b/ceph_deploy/hosts/debian/uninstall.py
@@ -1,6 +1,3 @@
-from ceph_deploy.util import pkg_managers
-
-
 def uninstall(distro, purge=False):
     packages = [
         'ceph',
@@ -9,8 +6,7 @@ def uninstall(distro, purge=False):
         'ceph-fs-common',
         'radosgw',
         ]
-    pkg_managers.apt_remove(
-        distro.conn,
+    distro.packager.remove(
         packages,
         purge=purge,
     )

--- a/ceph_deploy/hosts/rhel/__init__.py
+++ b/ceph_deploy/hosts/rhel/__init__.py
@@ -2,6 +2,7 @@ import mon  # noqa
 import pkg  # noqa
 from install import install, mirror_install, repo_install  # noqa
 from uninstall import uninstall  # noqa
+from ceph_deploy.util import pkg_managers
 
 # Allow to set some information about this distro
 #
@@ -17,3 +18,7 @@ def choose_init():
     Returns the name of a init system (upstart, sysvinit ...).
     """
     return 'sysvinit'
+
+
+def get_packager(module):
+    return pkg_managers.Yum(module)

--- a/ceph_deploy/hosts/rhel/install.py
+++ b/ceph_deploy/hosts/rhel/install.py
@@ -1,11 +1,11 @@
-from ceph_deploy.util import pkg_managers, templates
+from ceph_deploy.util import templates
 from ceph_deploy.lib import remoto
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):
     packages = kw.get('components', [])
-    pkg_managers.yum_clean(distro.conn)
-    pkg_managers.yum(distro.conn, packages)
+    distro.packager.clean()
+    distro.packager.install(packages)
 
 
 def mirror_install(distro, repo_url,
@@ -14,7 +14,7 @@ def mirror_install(distro, repo_url,
     repo_url = repo_url.strip('/')  # Remove trailing slashes
     gpg_url_path = gpg_url.split('file://')[-1]  # Remove file if present
 
-    pkg_managers.yum_clean(distro.conn)
+    distro.packager.clean()
 
     if adjust_repos:
         remoto.process.run(
@@ -33,8 +33,8 @@ def mirror_install(distro, repo_url,
 
         distro.conn.remote_module.write_yum_repo(ceph_repo_content)
 
-    if extra_installs:
-        pkg_managers.yum(distro.conn, packages)
+    if extra_installs and packages:
+        distro.packager.install(packages)
 
 
 def repo_install(distro, reponame, baseurl, gpgkey, **kw):
@@ -51,7 +51,7 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     _type = 'repo-md'
     baseurl = baseurl.strip('/')  # Remove trailing slashes
 
-    pkg_managers.yum_clean(distro.conn)
+    distro.packager.clean()
 
     if gpgkey:
         remoto.process.run(
@@ -81,5 +81,5 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     )
 
     # Some custom repos do not need to install ceph
-    if install_ceph:
-        pkg_managers.yum(distro.conn, packages)
+    if install_ceph and packages:
+        distro.packager.install(packages)

--- a/ceph_deploy/hosts/rhel/uninstall.py
+++ b/ceph_deploy/hosts/rhel/uninstall.py
@@ -1,6 +1,3 @@
-from ceph_deploy.util import pkg_managers
-
-
 def uninstall(distro, purge=False):
     packages = [
         'ceph',
@@ -10,9 +7,5 @@ def uninstall(distro, purge=False):
         'ceph-radosgw'
         ]
 
-    pkg_managers.yum_remove(
-        distro.conn,
-        packages,
-    )
-
-    pkg_managers.yum_clean(distro.conn)
+    distro.packager.remove(packages)
+    distro.packager.clean()

--- a/ceph_deploy/hosts/suse/__init__.py
+++ b/ceph_deploy/hosts/suse/__init__.py
@@ -4,6 +4,8 @@ from install import install, mirror_install, repo_install  # noqa
 from uninstall import uninstall  # noqa
 import logging
 
+from ceph_deploy.util import pkg_managers
+
 # Allow to set some information about this distro
 #
 
@@ -24,3 +26,7 @@ def choose_init():
         '13.1' : 'systemd',             # openSUSE_13.1
         }
     return init_mapping.get(release, 'sysvinit')
+
+
+def get_packager(module):
+    return pkg_managers.Zypper(module)

--- a/ceph_deploy/hosts/suse/install.py
+++ b/ceph_deploy/hosts/suse/install.py
@@ -1,6 +1,6 @@
 import logging
 
-from ceph_deploy.util import templates, pkg_managers
+from ceph_deploy.util import templates
 from ceph_deploy.lib import remoto
 from ceph_deploy.hosts.common import map_components
 
@@ -15,9 +15,9 @@ def install(distro, version_kind, version, adjust_repos, **kw):
         kw.get('components', [])
     )
 
-    pkg_managers.zypper_refresh(distro.conn)
-    if len(packages):
-        pkg_managers.zypper(distro.conn, packages)
+    distro.packager.clean()
+    if packages:
+        distro.packager.install(packages)
 
 
 def mirror_install(distro, repo_url, gpg_url, adjust_repos, **kw):
@@ -45,10 +45,10 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos, **kw):
         distro.conn.remote_module.write_file(
             '/etc/zypp/repos.d/ceph.repo',
             ceph_repo_content)
-        pkg_managers.zypper_refresh(distro.conn)
+        distro.packager.clean()
 
-    if len(packages):
-        pkg_managers.zypper(distro.conn, packages)
+    if packages:
+        distro.packager.install(packages)
 
 
 def repo_install(distro, reponame, baseurl, gpgkey, **kw):
@@ -92,5 +92,5 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     )
 
     # Some custom repos do not need to install ceph
-    if install_ceph and len(packages):
-        pkg_managers.zypper(distro.conn, packages)
+    if install_ceph and packages:
+        distro.packager.install(packages)

--- a/ceph_deploy/hosts/suse/uninstall.py
+++ b/ceph_deploy/hosts/suse/uninstall.py
@@ -1,6 +1,3 @@
-from ceph_deploy.util import pkg_managers
-
-
 def uninstall(distro, purge=False):
     packages = [
         'ceph',
@@ -10,4 +7,4 @@ def uninstall(distro, purge=False):
         'librbd1',
         'ceph-radosgw',
         ]
-    pkg_managers.zypper_remove(distro.conn, packages)
+    distro.packager.remove(packages)

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -276,3 +276,51 @@ class Yum(RPMManagerBase):
             if self.remote_info.normalized_release.int_major != 6:
                 package_name = 'yum-priorities'
         self.install(package_name)
+
+
+class Apt(PackageManager):
+    """
+    Apt package management
+    """
+
+    executable = [
+        'env',
+        'DEBIAN_FRONTEND=noninteractive',
+        'DEBIAN_PRIORITY=critical',
+        'apt-get',
+        '--assume-yes',
+        '-q',
+    ]
+
+    def install(self, packages, force_confnew=False):
+        if isinstance(packages, str):
+            packages = [packages]
+
+        cmd = self.executable + [
+            '--no-install-recommends',
+            'install'
+        ]
+
+        if force_confnew:
+            cmd.extend(['-o', 'Dpkg::Options::=--force-confnew'])
+        cmd.extend(packages)
+        return self._run(cmd)
+
+    def remove(self, packages, purge=False):
+        if isinstance(packages, str):
+            packages = [packages]
+
+        cmd = self.executable + [
+            '-f',
+            '--force-yes',
+            'remove'
+        ]
+
+        if purge:
+            cmd.append('--purge')
+        cmd.extend(packages)
+        return self._run(cmd)
+
+    def clean(self):
+        cmd = self.executable + ['update']
+        return self._run(cmd)

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -324,3 +324,35 @@ class Apt(PackageManager):
     def clean(self):
         cmd = self.executable + ['update']
         return self._run(cmd)
+
+
+class Zypper(PackageManager):
+    """
+    Zypper package management
+    """
+
+    executable = [
+        'zypper',
+        '--non-interactive',
+        '--quiet'
+    ]
+
+    def install(self, packages):
+        if isinstance(packages, str):
+            packages = [packages]
+
+        cmd = self.executable + ['install']
+        cmd.extend(packages)
+        return self._run(cmd)
+
+    def remove(self, packages):
+        if isinstance(packages, str):
+            packages = [packages]
+
+        cmd = self.executable + ['remove']
+        cmd.extend(packages)
+        return self._run(cmd)
+
+    def clean(self):
+        cmd = self.executable + ['refresh']
+        return self._run(cmd)


### PR DESCRIPTION
First added for Fedora/DNF, move all the other install/uninstall tasks to using the pkg manager classes.

There is still more work to do on top of this, but this is a big start.

Tested install/uninstall on CentOS 7, Trusty, and RHEL 7 and had no problems here.

http://tracker.ceph.com/issues/12439