### PR TITLE
Add "ceph-deploy repo" command

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -64,14 +64,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
 
     if adjust_repos:
         if version_kind != 'dev':
-            remoto.process.run(
-                distro.conn,
-                [
-                    'rpm',
-                    '--import',
-                    gpg.url(key)
-                ]
-            )
+            distro.packager.add_repo_gpg_key(gpg.url(key))
 
             if version_kind == 'stable':
                 url = 'http://ceph.com/rpm-{version}/{repo}/'.format(
@@ -120,19 +113,11 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos, extra_installs=True,
         kw.pop('components', [])
     )
     repo_url = repo_url.strip('/')  # Remove trailing slashes
-    gpg_url_path = gpg_url.split('file://')[-1]  # Remove file if present
 
     distro.packager.clean()
 
     if adjust_repos:
-        remoto.process.run(
-            distro.conn,
-            [
-                'rpm',
-                '--import',
-                gpg_url_path,
-            ]
-        )
+        distro.packager.add_repo_gpg_key(gpg_url)
 
         ceph_repo_content = templates.ceph_repo.format(
             repo_url=repo_url,
@@ -168,14 +153,7 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     distro.packager.clean()
 
     if gpgkey:
-        remoto.process.run(
-            distro.conn,
-            [
-                'rpm',
-                '--import',
-                gpgkey,
-            ]
-        )
+        distro.packager.add_repo_gpg_key(gpgkey)
 
     repo_content = templates.custom_repo(
         reponame=reponame,

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -28,14 +28,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
         logger.warning('check_obsoletes has been enabled for Yum priorities plugin')
 
         if version_kind != 'dev':
-            remoto.process.run(
-                distro.conn,
-                [
-                    'rpm',
-                    '--import',
-                    gpg.url(key)
-                ]
-            )
+            distro.packager.add_repo_gpg_key(gpg.url(key))
 
             if version_kind == 'stable':
                 url = 'http://ceph.com/rpm-{version}/fc{release}/'.format(

--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -215,6 +215,9 @@ def write_file(path, content, mode=0644, directory=None, uid=-1, gid=-1):
         if path.startswith("/"):
             path = path[1:]
         path = os.path.join(directory, path)
+    if os.path.exists(path):
+        # Delete file in case we are changing its mode
+        os.unlink(path)
     with os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT, mode), 'w') as f:
         f.write(content)
     os.chown(path, uid, gid)

--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -41,14 +41,14 @@ def machine_type():
     return platform.machine()
 
 
-def write_sources_list(url, codename, filename='ceph.list'):
+def write_sources_list(url, codename, filename='ceph.list', mode=0644):
     """add deb repo to /etc/apt/sources.list.d/"""
     repo_path = os.path.join('/etc/apt/sources.list.d', filename)
-    with file(repo_path, 'w') as f:
-        f.write('deb {url} {codename} main\n'.format(
-                url=url,
-                codename=codename,
-                ))
+    content = 'deb {url} {codename} main\n'.format(
+        url=url,
+        codename=codename,
+    )
+    write_file(repo_path, content, mode)
 
 
 def write_yum_repo(content, filename='ceph.repo'):

--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -42,7 +42,7 @@ def machine_type():
 
 
 def write_sources_list(url, codename, filename='ceph.list'):
-    """add deb repo to sources.list"""
+    """add deb repo to /etc/apt/sources.list.d/"""
     repo_path = os.path.join('/etc/apt/sources.list.d', filename)
     with file(repo_path, 'w') as f:
         f.write('deb {url} {codename} main\n'.format(
@@ -52,7 +52,7 @@ def write_sources_list(url, codename, filename='ceph.list'):
 
 
 def write_yum_repo(content, filename='ceph.repo'):
-    """set the contents of repo file to /etc/yum.repos.d/"""
+    """add yum repo file in /etc/yum.repos.d/"""
     repo_path = os.path.join('/etc/yum.repos.d', filename)
     write_file(repo_path, content)
 

--- a/ceph_deploy/hosts/rhel/install.py
+++ b/ceph_deploy/hosts/rhel/install.py
@@ -1,5 +1,4 @@
 from ceph_deploy.util import templates
-from ceph_deploy.lib import remoto
 
 
 def install(distro, version_kind, version, adjust_repos, **kw):
@@ -12,19 +11,11 @@ def mirror_install(distro, repo_url,
                    gpg_url, adjust_repos, extra_installs=True, **kw):
     packages = kw.get('components', [])
     repo_url = repo_url.strip('/')  # Remove trailing slashes
-    gpg_url_path = gpg_url.split('file://')[-1]  # Remove file if present
 
     distro.packager.clean()
 
     if adjust_repos:
-        remoto.process.run(
-            distro.conn,
-            [
-                'rpm',
-                '--import',
-                gpg_url_path,
-            ]
-        )
+        distro.packager.add_repo_gpg_key(gpg_url)
 
         ceph_repo_content = templates.ceph_repo.format(
             repo_url=repo_url,
@@ -54,14 +45,7 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
     distro.packager.clean()
 
     if gpgkey:
-        remoto.process.run(
-            distro.conn,
-            [
-                'rpm',
-                '--import',
-                gpgkey,
-            ]
-        )
+        distro.packager.add_repo_gpg_key(gpgkey)
 
     repo_content = templates.custom_repo(
         reponame=reponame,

--- a/ceph_deploy/repo.py
+++ b/ceph_deploy/repo.py
@@ -1,0 +1,50 @@
+import logging
+
+from ceph_deploy.cliutil import priority
+
+
+LOG = logging.getLogger(__name__)
+
+
+def repo(args):
+    pass
+
+
+@priority(70)
+def make(parser):
+    """
+    Repo definition management
+    """
+
+    parser.add_argument(
+        'repo_name',
+        metavar='REPO-NAME',
+        help='Name of repo to manage.  Can match an entry in cephdeploy.conf'
+    )
+
+    parser.add_argument(
+        '--repo-url',
+        help='a repo URL that mirrors/contains Ceph packages'
+    )
+
+    parser.add_argument(
+        '--gpg-url',
+        help='a GPG key URL to be used with custom repos'
+    )
+
+    parser.add_argument(
+        '--remove', '--delete',
+        action='store_true',
+        help='remove repo definition on remote host'
+    )
+
+    parser.add_argument(
+        'host',
+        metavar='HOST',
+        nargs='+',
+        help='host(s) to install on'
+    )
+
+    parser.set_defaults(
+        func=repo
+    )

--- a/ceph_deploy/repo.py
+++ b/ceph_deploy/repo.py
@@ -1,5 +1,6 @@
 import logging
 
+from ceph_deploy import hosts
 from ceph_deploy.cliutil import priority
 
 
@@ -7,7 +8,26 @@ LOG = logging.getLogger(__name__)
 
 
 def repo(args):
-    pass
+    cd_conf = getattr(args, 'cd_conf', None)
+
+    for hostname in args.host:
+        LOG.debug('Detecting platform for host %s ...', hostname)
+        distro = hosts.get(
+            hostname,
+            username=args.username
+        )
+        rlogger = logging.getLogger(hostname)
+
+        LOG.info(
+            'Distro info: %s %s %s',
+            distro.name,
+            distro.release,
+            distro.codename
+        )
+
+        if args.remove:
+            distro.packager.remove_repo(args.repo_name)
+
 
 
 @priority(70)

--- a/ceph_deploy/repo.py
+++ b/ceph_deploy/repo.py
@@ -1,3 +1,4 @@
+import os
 import logging
 
 from ceph_deploy import hosts
@@ -20,8 +21,8 @@ def install_repo(distro, args, cd_conf, rlogger):
                 'missing required key: %s in config section: %s' % (err, args.repo_name)
             )
     else:
-        repo_url = args.repo_url
-        gpg_url = args.gpg_url
+        repo_url = os.environ.get('CEPH_DEPLOY_REPO_URL') or args.repo_url
+        gpg_url = os.environ.get('CEPH_DEPLOY_GPG_URL') or args.gpg_url
         extra_repos = []
 
     repo_url = repo_url.strip('/')  # Remove trailing slashes

--- a/ceph_deploy/tests/parser/test_repo.py
+++ b/ceph_deploy/tests/parser/test_repo.py
@@ -1,0 +1,70 @@
+import pytest
+
+from ceph_deploy.cli import get_parser
+
+
+class TestParserRepo(object):
+
+    def setup(self):
+        self.parser = get_parser()
+
+    def test_repo_help(self, capsys):
+        with pytest.raises(SystemExit):
+            self.parser.parse_args('repo --help'.split())
+        out, err = capsys.readouterr()
+        assert 'usage: ceph-deploy repo' in out
+        assert 'positional arguments:' in out
+        assert 'optional arguments:' in out
+
+    def test_repo_name_required(self, capsys):
+        with pytest.raises(SystemExit):
+            self.parser.parse_args('repo'.split())
+        out, err = capsys.readouterr()
+        assert "error: too few arguments" in err
+
+    def test_repo_host_required(self, capsys):
+        with pytest.raises(SystemExit):
+            self.parser.parse_args('repo ceph'.split())
+        out, err = capsys.readouterr()
+        assert "error: too few arguments" in err
+
+    def test_repo_one_host(self):
+        args = self.parser.parse_args('repo ceph host1'.split())
+        assert args.host == ['host1']
+
+    def test_repo_multiple_hosts(self):
+        hostnames = ['host1', 'host2', 'host3']
+        args = self.parser.parse_args(['repo', 'ceph'] + hostnames)
+        assert frozenset(args.host) == frozenset(hostnames)
+
+    def test_repo_name(self):
+        args = self.parser.parse_args('repo ceph host1'.split())
+        assert args.repo_name == 'ceph'
+
+    def test_repo_remove_default_is_false(self):
+        args = self.parser.parse_args('repo ceph host1'.split())
+        assert not args.remove
+
+    def test_repo_remove_set_true(self):
+        args = self.parser.parse_args('repo ceph --remove host1'.split())
+        assert args.remove
+
+    def test_repo_remove_delete_alias(self):
+        args = self.parser.parse_args('repo ceph --delete host1'.split())
+        assert args.remove
+
+    def test_repo_url_default_is_none(self):
+        args = self.parser.parse_args('repo ceph host1'.split())
+        assert args.repo_url is None
+
+    def test_repo_url_custom_path(self):
+        args = self.parser.parse_args('repo ceph --repo-url https://ceph.com host1'.split())
+        assert args.repo_url == "https://ceph.com"
+
+    def test_repo_gpg_url_default_is_none(self):
+        args = self.parser.parse_args('repo ceph host1'.split())
+        assert args.gpg_url is None
+
+    def test_repo_gpg_url_custom_path(self):
+        args = self.parser.parse_args('repo ceph --gpg-url https://ceph.com/key host1'.split())
+        assert args.gpg_url == "https://ceph.com/key"

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -1,3 +1,5 @@
+import os
+
 from ceph_deploy.lib import remoto
 
 
@@ -215,6 +217,10 @@ class PackageManager(object):
         """Add/rewrite a repo file"""
         raise NotImplementedError()
 
+    def remove_repo(self, name):
+        """Remove a repo definition"""
+        raise NotImplementedError()
+
 
 class RPMManagerBase(PackageManager):
     """
@@ -266,6 +272,13 @@ class RPMManagerBase(PackageManager):
         gpg_url = kw.pop('gpg_url', None)
         if gpg_url:
             self.add_repo_gpg_key(gpg_url)
+
+    def remove_repo(self, name):
+        filename = os.path.join(
+            '/etc/yum.repos.d',
+            '%s.repo' % name
+        )
+        self.remote_conn.remote_module.unlink(filename)
 
 
 class DNF(RPMManagerBase):
@@ -363,6 +376,14 @@ class Apt(PackageManager):
             self.remote_info.codename,
             safe_filename
         )
+
+    def remove_repo(self, name):
+        safe_filename = '%s.list' % name.replace(' ', '-')
+        filename = os.path.join(
+            '/etc/apt/sources.list.d',
+            safe_filename
+        )
+        self.remote_conn.remote_module.unlink(filename)
 
 
 class Zypper(PackageManager):

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -188,10 +188,11 @@ class PackageManager(object):
         self.remote_info = remote_conn
         self.remote_conn = remote_conn.conn
 
-    def _run(self, cmd):
+    def _run(self, cmd, **kw):
         return remoto.process.run(
             self.remote_conn,
-            cmd
+            cmd,
+            **kw
         )
 
     def install(self, packages):

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -400,10 +400,17 @@ class Apt(PackageManager):
             self.add_repo_gpg_key(gpg_url)
 
         safe_filename = '%s.list' % name.replace(' ', '-')
+        mode = 0644
+        if urlparse(url).password:
+            mode = 0600
+            self.remote_conn.logger.info(
+                "Creating repo file with mode 0600 due to presence of password"
+            )
         self.remote_conn.remote_module.write_sources_list(
             url,
             self.remote_info.codename,
-            safe_filename
+            safe_filename,
+            mode
         )
 
         # Add package pinning for this repo

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -258,6 +258,15 @@ class RPMManagerBase(PackageManager):
 
         return self._run(cmd)
 
+    def add_repo_gpg_key(self, url):
+        cmd = ['rpmkeys', '--import', url]
+        self._run(cmd)
+
+    def add_repo(self, name, url, **kw):
+        gpg_url = kw.pop('gpg_url', None)
+        if gpg_url:
+            self.add_repo_gpg_key(gpg_url)
+
 
 class DNF(RPMManagerBase):
     """

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -1,4 +1,5 @@
 import os
+from urlparse import urlparse
 
 from ceph_deploy.lib import remoto
 from ceph_deploy.util import templates
@@ -404,6 +405,10 @@ class Apt(PackageManager):
             self.remote_info.codename,
             safe_filename
         )
+
+        # Add package pinning for this repo
+        fqdn = urlparse(url).hostname
+        self.remote_conn.remote_module.set_apt_priority(fqdn)
 
     def remove_repo(self, name):
         safe_filename = '%s.list' % name.replace(' ', '-')

--- a/ceph_deploy/util/templates.py
+++ b/ceph_deploy/util/templates.py
@@ -1,7 +1,6 @@
 
 
-ceph_repo = """
-[ceph]
+ceph_repo = """[ceph]
 name=Ceph packages for $basearch
 baseurl={repo_url}/$basearch
 enabled=1

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
             'pkg = ceph_deploy.pkg:make',
             'calamari = ceph_deploy.calamari:make',
             'rgw = ceph_deploy.rgw:make',
+            'repo = ceph_deploy.repo:make',
             ],
 
         },


### PR DESCRIPTION
This introduces a new `ceph-deploy repo` set of commands.

You can use `ceph-deploy repo` to create or delete repo files by name.  The repo details can be passed in my `--gpg-url` and `--repo-url`.  Note that for RPM systems, this command only supports the basic "ceph" template -- meaning that it will always put three entries into a single `.repo` file for [ceph], [ceph-noarch], and [ceph-source].

We could potentially swap this out for the more flexible custom/arbitrary repo definitions if that is deemed worthwhile.  Even if we think that it might be, let's talk about it because I don't want to **not** be able to switch to it later for backwards compatibility reasons because we didn't start that way.

I haven't tested yet that this works when reading repos from `cephdeploy.conf`.  I need to check that next.  I did test that `--remove` worked on CentOS7 and Trusty, and that I could create valid repo definitions using `--gpg-url` and `--repo-url` on those same two distros.

Another future TODO is to add support for reading the repo/gpg URL from env vars (as is done in another place of the code) so that security conscious users can use those to input URLs that use HTTP basic auth (e.g. https://{user}:{password}@fqdn/repo/....).