### PR TITLE
Only install priorities plugin when using Yum

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -54,7 +54,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
     # Get EPEL installed before we continue:
     if adjust_repos:
         distro.packager.install('epel-release')
-        distro.packager.install_priorities_plugin()
+        distro.packager.install('yum-plugin-priorities')
         distro.conn.remote_module.enable_yum_priority_obsoletes()
         logger.warning('check_obsoletes has been enabled for Yum priorities plugin')
     if version_kind in ['stable', 'testing']:
@@ -141,9 +141,10 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos, extra_installs=True,
 
         distro.conn.remote_module.write_yum_repo(ceph_repo_content)
         # set the right priority
-        distro.packager.install_priorities_plugin()
+        if distro.packager.name == 'yum':
+            distro.packager.install('yum-plugin-priorities')
         distro.conn.remote_module.set_repo_priority(['Ceph', 'Ceph-noarch', 'ceph-source'])
-        distro.conn.logger.warning('alter.d ceph.repo priorities to contain: priority=1')
+        distro.conn.logger.warning('altered ceph.repo priorities to contain: priority=1')
 
 
     if extra_installs and packages:
@@ -198,11 +199,8 @@ def repo_install(distro, reponame, baseurl, gpgkey, **kw):
 
     # set the right priority
     if kw.get('priority'):
-        distro.packager.install_priorities_plugin()
-        logger.warning(
-            'ensuring that {repo_path} contains a high priority'.format(
-                repo_path=repo_path)
-        )
+        if distro.packager.name == 'yum':
+            distro.packager.install('yum-plugin-priorities')
 
         distro.conn.remote_module.set_repo_priority([reponame], repo_path)
         logger.warning('altered {reponame}.repo priorities to contain: priority=1'.format(

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -22,10 +22,11 @@ def install(distro, version_kind, version, adjust_repos, **kw):
         key = 'autobuild'
 
     if adjust_repos:
-        distro.packager.install_priorities_plugin()
-        # haven't been able to determine necessity of check_obsoletes with DNF
-        distro.conn.remote_module.enable_yum_priority_obsoletes()
-        logger.warning('check_obsoletes has been enabled for Yum priorities plugin')
+        if distro.packager.name == 'yum':
+            distro.packager.install('yum-plugin-priorities')
+            # haven't been able to determine necessity of check_obsoletes with DNF
+            distro.conn.remote_module.enable_yum_priority_obsoletes()
+            logger.warning('check_obsoletes has been enabled for Yum priorities plugin')
 
         if version_kind != 'dev':
             remoto.process.run(

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -213,6 +213,7 @@ class RPMManagerBase(PackageManager):
     """
 
     executable = None
+    name = None
 
     def install(self, packages):
         if isinstance(packages, str):
@@ -256,6 +257,7 @@ class DNF(RPMManagerBase):
     """
 
     executable = 'dnf'
+    name = 'dnf'
 
     def install_priorities_plugin(self):
         # DNF supports priorities natively
@@ -268,6 +270,7 @@ class Yum(RPMManagerBase):
     """
 
     executable = 'yum'
+    name = 'yum'
 
     def install_priorities_plugin(self):
         package_name = 'yum-plugin-priorities'
@@ -291,6 +294,7 @@ class Apt(PackageManager):
         '--assume-yes',
         '-q',
     ]
+    name = 'apt'
 
     def install(self, packages, force_confnew=False):
         if isinstance(packages, str):
@@ -336,6 +340,7 @@ class Zypper(PackageManager):
         '--non-interactive',
         '--quiet'
     ]
+    name = 'zypper'
 
     def install(self, packages):
         if isinstance(packages, str):

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -259,10 +259,6 @@ class DNF(RPMManagerBase):
     executable = 'dnf'
     name = 'dnf'
 
-    def install_priorities_plugin(self):
-        # DNF supports priorities natively
-        pass
-
 
 class Yum(RPMManagerBase):
     """
@@ -271,14 +267,6 @@ class Yum(RPMManagerBase):
 
     executable = 'yum'
     name = 'yum'
-
-    def install_priorities_plugin(self):
-        package_name = 'yum-plugin-priorities'
-
-        if self.remote_info.normalized_name == 'centos':
-            if self.remote_info.normalized_release.int_major != 6:
-                package_name = 'yum-priorities'
-        self.install(package_name)
 
 
 class Apt(PackageManager):


### PR DESCRIPTION
Since DNF natively supports priorities, just skip all the priorities stuff if we're not Yum.

Skip the check_obsoletes on DNF as well.

I didn't like having a "install_specific_package...()" method in the package manager classes, so I created a helper to return the name and just used the regular install() method instead.

Tested on CentOS and Fedora.  Seems to work!

http://tracker.ceph.com/issues/12477