### PR TITLE
Allow package upgrades with DNF

### DIFF
--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -53,7 +53,10 @@ def install(distro, version_kind, version, adjust_repos, **kw):
 
     # TODO this does not downgrade -- should it?
     if packages:
-        distro.packager.install(packages, force_confnew=True)
+        distro.packager.install(
+            packages,
+            extra_install_flags=['-o', 'Dpkg::Options::=--force-confnew']
+        )
 
 
 def mirror_install(distro, repo_url, gpg_url, adjust_repos, **kw):

--- a/ceph_deploy/hosts/debian/uninstall.py
+++ b/ceph_deploy/hosts/debian/uninstall.py
@@ -6,7 +6,10 @@ def uninstall(distro, purge=False):
         'ceph-fs-common',
         'radosgw',
         ]
+    extra_remove_flags = []
+    if purge:
+        extra_remove_flags.append('--purge')
     distro.packager.remove(
         packages,
-        purge=purge,
+        extra_remove_flags=extra_remove_flags
     )

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -56,6 +56,11 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                 ]
             )
 
+            # set the right priority
+            logger.warning('ensuring that /etc/yum.repos.d/ceph.repo contains a high priority')
+            distro.conn.remote_module.set_repo_priority(['Ceph', 'Ceph-noarch', 'ceph-source'])
+            logger.warning('altered ceph.repo priorities to contain: priority=1')
+
         if version_kind == 'dev':
             logger.info('skipping install of ceph-release package')
             logger.info('repo file will be created manually')
@@ -69,11 +74,6 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                 adjust_repos=True,
                 extra_installs=False
             )
-
-        # set the right priority
-        logger.warning('ensuring that /etc/yum.repos.d/ceph.repo contains a high priority')
-        distro.conn.remote_module.set_repo_priority(['Ceph', 'Ceph-noarch', 'ceph-source'])
-        logger.warning('altered ceph.repo priorities to contain: priority=1')
 
     distro.packager.install(
         packages

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -199,7 +199,7 @@ class PackageManager(object):
             **kw
         )
 
-    def install(self, packages):
+    def install(self, packages, **kw):
         """Install packages on remote node"""
         raise NotImplementedError()
 
@@ -232,15 +232,21 @@ class RPMManagerBase(PackageManager):
     executable = None
     name = None
 
-    def install(self, packages):
+    def install(self, packages, **kw):
         if isinstance(packages, str):
             packages = [packages]
 
+        extra_flags = kw.pop('extra_install_flags', None)
         cmd = [
             self.executable,
             '-y',
             'install',
         ]
+        if extra_flags:
+            if isinstance(extra_flags, str):
+                extra_flags = [extra_flags]
+            cmd.extend(extra_flags)
+
         cmd.extend(packages)
         return self._run(cmd)
 
@@ -344,15 +350,20 @@ class Apt(PackageManager):
     ]
     name = 'apt'
 
-    def install(self, packages, force_confnew=False):
+    def install(self, packages, force_confnew=False, **kw):
         if isinstance(packages, str):
             packages = [packages]
 
+        extra_flags = kw.pop('extra_install_flags', None)
         cmd = self.executable + [
             '--no-install-recommends',
             'install'
         ]
 
+        if extra_flags:
+            if isinstance(extra_flags, str):
+                extra_flags = [extra_flags]
+            cmd.extend(extra_flags)
         if force_confnew:
             cmd.extend(['-o', 'Dpkg::Options::=--force-confnew'])
         cmd.extend(packages)
@@ -430,11 +441,16 @@ class Zypper(PackageManager):
     ]
     name = 'zypper'
 
-    def install(self, packages):
+    def install(self, packages, **kw):
         if isinstance(packages, str):
             packages = [packages]
 
+        extra_flags = kw.pop('extra_install_flags', None)
         cmd = self.executable + ['install']
+        if extra_flags:
+            if isinstance(extra_flags, str):
+                extra_flags = [extra_flags]
+            cmd.extend(extra_flags)
         cmd.extend(packages)
         return self._run(cmd)
 

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -382,7 +382,7 @@ class Apt(PackageManager):
         cmd.extend(packages)
         return self._run(cmd)
 
-    def remove(self, packages, purge=False, **kw):
+    def remove(self, packages, **kw):
         if isinstance(packages, str):
             packages = [packages]
 
@@ -397,8 +397,6 @@ class Apt(PackageManager):
                 extra_flags = [extra_flags]
             cmd.extend(extra_flags)
 
-        if purge:
-            cmd.append('--purge')
         cmd.extend(packages)
         return self._run(cmd)
 

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -360,7 +360,7 @@ class Apt(PackageManager):
     ]
     name = 'apt'
 
-    def install(self, packages, force_confnew=False, **kw):
+    def install(self, packages, **kw):
         if isinstance(packages, str):
             packages = [packages]
 
@@ -374,8 +374,6 @@ class Apt(PackageManager):
             if isinstance(extra_flags, str):
                 extra_flags = [extra_flags]
             cmd.extend(extra_flags)
-        if force_confnew:
-            cmd.extend(['-o', 'Dpkg::Options::=--force-confnew'])
         cmd.extend(packages)
         return self._run(cmd)
 

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -203,7 +203,7 @@ class PackageManager(object):
         """Install packages on remote node"""
         raise NotImplementedError()
 
-    def remove(self, packages):
+    def remove(self, packages, **kw):
         """Uninstall packages on remote node"""
         raise NotImplementedError()
 
@@ -250,16 +250,21 @@ class RPMManagerBase(PackageManager):
         cmd.extend(packages)
         return self._run(cmd)
 
-    def remove(self, packages):
+    def remove(self, packages, **kw):
         if isinstance(packages, str):
             packages = [packages]
 
+        extra_flags = kw.pop('extra_remove_flags', None)
         cmd = [
             self.executable,
             '-y',
             '-q',
             'remove',
         ]
+        if extra_flags:
+            if isinstance(extra_flags, str):
+                extra_flags = [extra_flags]
+            cmd.extend(extra_flags)
         cmd.extend(packages)
         return self._run(cmd)
 
@@ -377,15 +382,20 @@ class Apt(PackageManager):
         cmd.extend(packages)
         return self._run(cmd)
 
-    def remove(self, packages, purge=False):
+    def remove(self, packages, purge=False, **kw):
         if isinstance(packages, str):
             packages = [packages]
 
+        extra_flags = kw.pop('extra_remove_flags', None)
         cmd = self.executable + [
             '-f',
             '--force-yes',
             'remove'
         ]
+        if extra_flags:
+            if isinstance(extra_flags, str):
+                extra_flags = [extra_flags]
+            cmd.extend(extra_flags)
 
         if purge:
             cmd.append('--purge')
@@ -462,11 +472,16 @@ class Zypper(PackageManager):
         cmd.extend(packages)
         return self._run(cmd)
 
-    def remove(self, packages):
+    def remove(self, packages, **kw):
         if isinstance(packages, str):
             packages = [packages]
 
+        extra_flags = kw.pop('extra_remove_flags', None)
         cmd = self.executable + ['remove']
+        if extra_flags:
+            if isinstance(extra_flags, str):
+                extra_flags = [extra_flags]
+            cmd.extend(extra_flags)
         cmd.extend(packages)
         return self._run(cmd)
 

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -325,6 +325,16 @@ class DNF(RPMManagerBase):
     executable = 'dnf'
     name = 'dnf'
 
+    def install(self, packages, **kw):
+        extra_install_flags = kw.pop('extra_install_flags', [])
+        if '--best' not in extra_install_flags:
+            extra_install_flags.append('--best')
+        super(DNF, self).install(
+            packages,
+            extra_install_flags=extra_install_flags,
+            **kw
+        )
+
 
 class Yum(RPMManagerBase):
     """


### PR DESCRIPTION
Doing `dnf install pkg` does not actually upgrade the package if it is already installed.  But adding `--best` will make it do so.

There are more commits here than necessary to just add `--test` to the DNF call.  The other commits are to modify the install() and remove() methods of the package manager classes to take `**kw`, and to pass keyword args for adding extra flags to install and remove calls.

The individual commits make sense.

http://tracker.ceph.com/issues/12480