### PR TITLE
Do not enable non-existing ceph service on systemd managed EL distros.

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -68,7 +68,7 @@ def get(hostname,
     module.codename = codename
     module.conn = conn
     module.machine_type = machine_type
-    module.init = module.choose_init()
+    module.init = module.choose_init(module)
     module.packager = module.get_packager(module)
     return module
 

--- a/ceph_deploy/hosts/centos/__init__.py
+++ b/ceph_deploy/hosts/centos/__init__.py
@@ -12,7 +12,7 @@ release = None
 codename = None
 
 
-def choose_init():    
+def choose_init(module):
     """
     Select a init system
 

--- a/ceph_deploy/hosts/debian/__init__.py
+++ b/ceph_deploy/hosts/debian/__init__.py
@@ -11,7 +11,7 @@ distro = None
 release = None
 codename = None
 
-def choose_init():    
+def choose_init(module):
     """
     Select a init system
 

--- a/ceph_deploy/hosts/fedora/__init__.py
+++ b/ceph_deploy/hosts/fedora/__init__.py
@@ -12,14 +12,16 @@ distro = None
 release = None
 codename = None
 
-def choose_init():
+def choose_init(module):
     """
     Select a init system
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
-    return 'systemd'
-
+    if module.normalized_release.int_major >= 22:
+        return 'systemd'
+    else:
+        return 'sysvinit'
 
 def get_packager(module):
     if module.normalized_release.int_major >= 22:

--- a/ceph_deploy/hosts/rhel/__init__.py
+++ b/ceph_deploy/hosts/rhel/__init__.py
@@ -11,7 +11,7 @@ distro = None
 release = None
 codename = None
 
-def choose_init():
+def choose_init(module):
     """
     Select a init system
 

--- a/ceph_deploy/hosts/suse/__init__.py
+++ b/ceph_deploy/hosts/suse/__init__.py
@@ -15,7 +15,7 @@ distro = None
 release = None
 codename = None
 
-def choose_init():
+def choose_init(module):
     """
     Select a init system
 

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -379,8 +379,10 @@ def activate(args, cfg):
         time.sleep(5)
         catch_osd_errors(distro.conn, distro.conn.logger, args)
 
-        if distro.is_el:
-            system.enable_service(distro.conn)
+        if distro.init == 'systemd':
+            system.enable_service(distro.conn, "ceph.target")
+        elif distro.init == 'sysvinit':
+            system.enable_service(distro.conn, "ceph")
 
         distro.conn.exit()
 

--- a/ceph_deploy/tests/unit/hosts/test_suse.py
+++ b/ceph_deploy/tests/unit/hosts/test_suse.py
@@ -7,22 +7,22 @@ class TestSuseInit(object):
 
     def test_choose_init_default(self):
         self.host.release = None
-        init_type = self.host.choose_init()
+        init_type = self.host.choose_init(self.host)
         assert init_type == "sysvinit"
-        
+
     def test_choose_init_SLE_11(self):
         self.host.release = '11'
-        init_type = self.host.choose_init()
+        init_type = self.host.choose_init(self.host)
         assert init_type == "sysvinit"
 
     def test_choose_init_SLE_12(self):
         self.host.release = '12'
-        init_type = self.host.choose_init()
+        init_type = self.host.choose_init(self.host)
         assert init_type == "systemd"
 
     def test_choose_init_openSUSE_13_1(self):
         self.host.release = '13.1'
-        init_type = self.host.choose_init()
+        init_type = self.host.choose_init(self.host)
         assert init_type == "systemd"
 
 class TestSuseMapComponents(object):


### PR DESCRIPTION
Once systemd integration is ready, "systemctl enable ceph" fails
because there is no longer such service (OSD units are generated).

Signed-off-by: Milan Broz <mbroz@redhat.com>

Also see https://github.com/ceph/ceph-deploy/commit/8360fb501aa8a3b8dc20423c1575379b3d30690e