### PR TITLE
[RM-12631] catch syntax errors in tox runs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands=
 
 [testenv:flake8]
 deps=flake8
-commands=flake8 --select=F --exclude=vendor {posargs:ceph_deploy}
+commands=flake8 --select=F,E9 --exclude=vendor {posargs:ceph_deploy}
 
 # Note that ``remoto`` is not added as a dependency here as it is assumed
 # that the tester will have the distro version of remoto installed


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>

Reference issue: http://tracker.ceph.com/issues/12631