### PR TITLE
mon add: start new mon without calling 'ceph mon add'

### DIFF
--- a/ceph_deploy/hosts/common.py
+++ b/ceph_deploy/hosts/common.py
@@ -146,18 +146,6 @@ def mon_add(distro, args, monitor_keyring):
             ] + user_args
         )
 
-        # add it
-        remoto.process.run(
-            distro.conn,
-            [
-                'ceph',
-                'mon',
-                'add',
-                hostname,
-                args.address,
-            ],
-        )
-
         logger.info('unlinking keyring file %s' % keyring)
         distro.conn.remote_module.unlink(keyring)
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/12649

When going from 1 monitor to 2 (via ceph-deploy mon add), there is
a problem such that the existing monitor cannot reach quorum
once you "ceph mon add", because 2 mons require conensus.  But the
2nd monitor isn't running yet, so they are stuck.

As it turns out, calling `ceph mon add` is completely unnecessary, so just remove it entirely.

Via manual testing, I was able to move from 1-->2 mons, then 2-->3 mons without any problems with this change.

Fixes: #12649

Signed-off-by: Travis Rhoden <trhoden@redhat.com>