### PR TITLE
use 'rpm --import', not 'rpmkeys --import'

### DIFF
--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -101,7 +101,7 @@ class RPMManagerBase(PackageManager):
         return self._run(cmd)
 
     def add_repo_gpg_key(self, url):
-        cmd = ['rpmkeys', '--import', url]
+        cmd = ['rpm', '--import', url]
         self._run(cmd)
 
     def add_repo(self, name, url, **kw):


### PR DESCRIPTION
for EL6 compatibility

http://tracker.ceph.com/issues/12663

Signed-off-by: Travis Rhoden <trhoden@redhat.com>