### PR TITLE
Detect and support both systemd and sysvinit on Fedora, RHEL and CentOS

### DIFF
--- a/ceph_deploy/hosts/centos/__init__.py
+++ b/ceph_deploy/hosts/centos/__init__.py
@@ -17,8 +17,14 @@ def choose_init(module):
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
-    return 'sysvinit'
 
+    if module.normalized_release.int_major < 7:
+        return 'sysvinit'
+
+    if not module.conn.remote_module.path_exists("/usr/lib/systemd/system/ceph.target"):
+        return 'sysvinit'
+
+    return 'systemd'
 
 def get_packager(module):
     return pkg_managers.Yum(module)

--- a/ceph_deploy/hosts/centos/mon/create.py
+++ b/ceph_deploy/hosts/centos/mon/create.py
@@ -6,19 +6,51 @@ from ceph_deploy.lib import remoto
 def create(distro, args, monitor_keyring):
     hostname = distro.conn.remote_module.shortname()
     common.mon_create(distro, args, monitor_keyring, hostname)
-    service = distro.conn.remote_module.which_service()
 
-    remoto.process.run(
-        distro.conn,
-        [
-            service,
-            'ceph',
-            '-c',
-            '/etc/ceph/{cluster}.conf'.format(cluster=args.cluster),
-            'start',
-            'mon.{hostname}'.format(hostname=hostname)
-        ],
-        timeout=7,
-    )
+    if distro.init == 'sysvinit':
+        service = distro.conn.remote_module.which_service()
+        remoto.process.run(
+            distro.conn,
+            [
+                service,
+                'ceph',
+                '-c',
+                '/etc/ceph/{cluster}.conf'.format(cluster=args.cluster),
+                'start',
+                'mon.{hostname}'.format(hostname=hostname)
+            ],
+            timeout=7,
+        )
 
-    system.enable_service(distro.conn)
+        system.enable_service(distro.conn)
+    elif distro.init == 'systemd':
+       # enable ceph target for this host (in case it isn't already enabled)
+        remoto.process.run(
+            distro.conn,
+            [
+                'systemctl',
+                'enable',
+                'ceph.target'
+            ],
+            timeout=7,
+        )
+
+        # enable and start this mon instance
+        remoto.process.run(
+            distro.conn,
+            [
+                'systemctl',
+                'enable',
+                'ceph-mon@{hostname}'.format(hostname=hostname),
+            ],
+            timeout=7,
+        )
+        remoto.process.run(
+            distro.conn,
+            [
+                'systemctl',
+                'start',
+                'ceph-mon@{hostname}'.format(hostname=hostname),
+            ],
+            timeout=7,
+        )

--- a/ceph_deploy/hosts/fedora/__init__.py
+++ b/ceph_deploy/hosts/fedora/__init__.py
@@ -17,10 +17,11 @@ def choose_init(module):
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
-    if module.normalized_release.int_major >= 22:
-        return 'systemd'
-    else:
+
+    if not module.conn.remote_module.path_exists("/usr/lib/systemd/system/ceph.target"):
         return 'sysvinit'
+
+    return 'systemd'
 
 def get_packager(module):
     if module.normalized_release.int_major >= 22:

--- a/ceph_deploy/hosts/fedora/mon/create.py
+++ b/ceph_deploy/hosts/fedora/mon/create.py
@@ -1,4 +1,5 @@
 from ceph_deploy.hosts import common
+from ceph_deploy.util import system
 from ceph_deploy.lib import remoto
 
 
@@ -6,33 +7,50 @@ def create(distro, args, monitor_keyring):
     hostname = distro.conn.remote_module.shortname()
     common.mon_create(distro, args, monitor_keyring, hostname)
 
-    # enable ceph target for this host (in case it isn't already enabled)
-    remoto.process.run(
-        distro.conn,
-        [
-            'systemctl',
-            'enable',
-            'ceph.target'
-        ],
-        timeout=7,
-    )
+    if distro.init == 'sysvinit':
+        service = distro.conn.remote_module.which_service()
+        remoto.process.run(
+            distro.conn,
+            [
+                service,
+                'ceph',
+                '-c',
+                '/etc/ceph/{cluster}.conf'.format(cluster=args.cluster),
+                'start',
+                'mon.{hostname}'.format(hostname=hostname)
+            ],
+            timeout=7,
+        )
 
-    # enable and start this mon instance
-    remoto.process.run(
-        distro.conn,
-        [
-            'systemctl',
-            'enable',
-            'ceph-mon@{hostname}'.format(hostname=hostname),
-        ],
-        timeout=7,
-    )
-    remoto.process.run(
-        distro.conn,
-        [
-            'systemctl',
-            'start',
-            'ceph-mon@{hostname}'.format(hostname=hostname),
-        ],
-        timeout=7,
-    )
+        system.enable_service(distro.conn)
+    elif distro.init == 'systemd':
+       # enable ceph target for this host (in case it isn't already enabled)
+        remoto.process.run(
+            distro.conn,
+            [
+                'systemctl',
+                'enable',
+                'ceph.target'
+            ],
+            timeout=7,
+        )
+
+        # enable and start this mon instance
+        remoto.process.run(
+            distro.conn,
+            [
+                'systemctl',
+                'enable',
+                'ceph-mon@{hostname}'.format(hostname=hostname),
+            ],
+            timeout=7,
+        )
+        remoto.process.run(
+            distro.conn,
+            [
+                'systemctl',
+                'start',
+                'ceph-mon@{hostname}'.format(hostname=hostname),
+            ],
+            timeout=7,
+        )

--- a/ceph_deploy/hosts/rhel/__init__.py
+++ b/ceph_deploy/hosts/rhel/__init__.py
@@ -16,8 +16,14 @@ def choose_init(module):
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
-    return 'sysvinit'
 
+    if module.normalized_release.int_major < 7:
+        return 'sysvinit'
+
+    if not module.conn.remote_module.path_exists("/usr/lib/systemd/system/ceph.target"):
+        return 'sysvinit'
+
+    return 'systemd'
 
 def get_packager(module):
     return pkg_managers.Yum(module)

--- a/ceph_deploy/hosts/rhel/mon/create.py
+++ b/ceph_deploy/hosts/rhel/mon/create.py
@@ -6,19 +6,51 @@ from ceph_deploy.lib import remoto
 def create(distro, args, monitor_keyring):
     hostname = distro.conn.remote_module.shortname()
     common.mon_create(distro, args, monitor_keyring, hostname)
-    service = distro.conn.remote_module.which_service()
 
-    remoto.process.run(
-        distro.conn,
-        [
-            service,
-            'ceph',
-            '-c',
-            '/etc/ceph/{cluster}.conf'.format(cluster=args.cluster),
-            'start',
-            'mon.{hostname}'.format(hostname=hostname)
-        ],
-        timeout=7,
-    )
+    if distro.init == 'sysvinit':
+        service = distro.conn.remote_module.which_service()
+        remoto.process.run(
+            distro.conn,
+            [
+                service,
+                'ceph',
+                '-c',
+                '/etc/ceph/{cluster}.conf'.format(cluster=args.cluster),
+                'start',
+                'mon.{hostname}'.format(hostname=hostname)
+            ],
+            timeout=7,
+        )
 
-    system.enable_service(distro.conn)
+        system.enable_service(distro.conn)
+    elif distro.init == 'systemd':
+       # enable ceph target for this host (in case it isn't already enabled)
+        remoto.process.run(
+            distro.conn,
+            [
+                'systemctl',
+                'enable',
+                'ceph.target'
+            ],
+            timeout=7,
+        )
+
+        # enable and start this mon instance
+        remoto.process.run(
+            distro.conn,
+            [
+                'systemctl',
+                'enable',
+                'ceph-mon@{hostname}'.format(hostname=hostname),
+            ],
+            timeout=7,
+        )
+        remoto.process.run(
+            distro.conn,
+            [
+                'systemctl',
+                'start',
+                'ceph-mon@{hostname}'.format(hostname=hostname),
+            ],
+            timeout=7,
+        )


### PR DESCRIPTION
To properly install systemd-enabled and old (sysvinit) Ceph packages
we need to properly detect when systemd target is used.

This cannot be done just by checking distro version, it depends
on Ceph package content (sysvinit can be used on systemd distro as well).

Let's check ceph.target existence and enable systemd only in this case.

Signed-off-by: Milan Broz <mbroz@redhat.com>