### PR TITLE
check if ceph is installed

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -17,7 +17,8 @@ def get(hostname,
         username=None,
         fallback=None,
         detect_sudo=True,
-        use_rhceph=False):
+        use_rhceph=False,
+        callbacks=None):
     """
     Retrieve the module that matches the distribution of a ``hostname``. This
     function will connect to that host and retrieve the distribution
@@ -36,6 +37,10 @@ def get(hostname,
     :param use_rhceph: Whether or not to install RH Ceph on a RHEL machine or
                        the community distro.  Changes what host module is
                        returned for RHEL.
+    :params callbacks: A list of callables that accept one argument (the actual
+                       module that contains the connection) that will be
+                       called, in order at the end of the instantiation of the
+                       module.
     """
     conn = get_connection(
         hostname,
@@ -71,6 +76,10 @@ def get(hostname,
     module.machine_type = machine_type
     module.init = module.choose_init(module)
     module.packager = module.get_packager(module)
+    # execute each callback if any
+    if callbacks:
+        for c in callbacks:
+            c(module)
     return module
 
 

--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -6,6 +6,7 @@ on the type of distribution/version we are dealing with.
 """
 import logging
 from ceph_deploy import exc
+from ceph_deploy.util import versions
 from ceph_deploy.hosts import debian, centos, fedora, suse, remotes, rhel
 from ceph_deploy.connection import get_connection
 
@@ -121,21 +122,6 @@ def _normalized_release(release):
 
         normalized_version.int_major
     """
-    release = release.strip()
-
-    class NormalizedVersion(object):
-        pass
-    v = NormalizedVersion()  # fake object to get nice dotted access
-    v.major, v.minor, v.patch, v.garbage = (release.split('.') + ["0"]*4)[:4]
-    release_map = dict(major=v.major, minor=v.minor, patch=v.patch, garbage=v.garbage)
-
-    # safe int versions that remove non-numerical chars
-    # for example 'rc1' in a version like '1-rc1
-    for name, value in release_map.items():
-        if '-' in value:  # get rid of garbage like -dev1 or -rc1
-            value = value.split('-')[0]
-        value = float(''.join(c for c in value if c.isdigit()) or 0)
-        int_name = "int_%s" % name
-        setattr(v, int_name, value)
-
-    return v
+    # TODO: at some point deprecate this function so that we just
+    # use this class directly (and update every test that calls it
+    return versions.NormalizedVersion(release)

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 from cStringIO import StringIO
 
 from ceph_deploy import conf, exc, hosts, mon
-from ceph_deploy.util import constants, system
+from ceph_deploy.util import constants, system, packages
 from ceph_deploy.cliutil import priority
 from ceph_deploy.lib import remoto
 
@@ -290,7 +290,11 @@ def prepare(args, cfg, activate_prepared_disk):
             if disk is None:
                 raise exc.NeedDiskError(hostname)
 
-            distro = hosts.get(hostname, username=args.username)
+            distro = hosts.get(
+                hostname,
+                username=args.username,
+                callbacks=[packages.ceph_is_installed]
+            )
             LOG.info(
                 'Distro info: %s %s %s',
                 distro.name,
@@ -352,7 +356,11 @@ def activate(args, cfg):
 
     for hostname, disk, journal in args.disk:
 
-        distro = hosts.get(hostname, username=args.username)
+        distro = hosts.get(
+            hostname,
+            username=args.username,
+            callbacks=[packages.ceph_is_installed]
+        )
         LOG.info(
             'Distro info: %s %s %s',
             distro.name,
@@ -393,7 +401,11 @@ def disk_zap(args):
         if not disk or not hostname:
             raise RuntimeError('zap command needs both HOSTNAME and DISK but got "%s %s"' % (hostname, disk))
         LOG.debug('zapping %s on %s', disk, hostname)
-        distro = hosts.get(hostname, username=args.username)
+        distro = hosts.get(
+            hostname,
+            username=args.username,
+            callbacks=[packages.ceph_is_installed]
+        )
         LOG.info(
             'Distro info: %s %s %s',
             distro.name,
@@ -444,7 +456,11 @@ def disk_zap(args):
 
 def disk_list(args, cfg):
     for hostname, disk, journal in args.disk:
-        distro = hosts.get(hostname, username=args.username)
+        distro = hosts.get(
+            hostname,
+            username=args.username,
+            callbacks=[packages.ceph_is_installed]
+        )
         LOG.info(
             'Distro info: %s %s %s',
             distro.name,
@@ -469,7 +485,12 @@ def osd_list(args, cfg):
 
     # get the osd tree from a monitor host
     mon_host = monitors[0]
-    distro = hosts.get(mon_host, username=args.username)
+    distro = hosts.get(
+        mon_host,
+        username=args.username,
+        callbacks=[packages.ceph_is_installed]
+    )
+
     tree = osd_tree(distro.conn, args.cluster)
     distro.conn.exit()
 

--- a/ceph_deploy/tests/unit/util/test_packages.py
+++ b/ceph_deploy/tests/unit/util/test_packages.py
@@ -1,0 +1,43 @@
+from mock import Mock, patch
+from ceph_deploy.exc import ExecutableNotFound
+from ceph_deploy.util import packages
+
+
+class TestCephIsInstalled(object):
+
+    def test_installed(self):
+        with patch('ceph_deploy.util.packages.system'):
+            c = packages.Ceph(Mock())
+            assert c.installed is True
+
+    def test_not_installed(self):
+        with patch('ceph_deploy.util.packages.system') as fsystem:
+            bad_executable = Mock(
+                side_effect=ExecutableNotFound('host', 'ceph')
+            )
+            fsystem.executable_path = bad_executable
+            c = packages.Ceph(Mock())
+            assert c.installed is False
+
+
+class TestCephVersion(object):
+
+    def test_executable_not_found(self):
+        with patch('ceph_deploy.util.packages.system') as fsystem:
+            bad_executable = Mock(
+                side_effect=ExecutableNotFound('host', 'ceph')
+            )
+            fsystem.executable_path = bad_executable
+            c = packages.Ceph(Mock())
+            assert c._get_version_output() == ''
+
+    def test_output_is_unusable(self):
+        _check = Mock(return_value=('', '', 1))
+        c = packages.Ceph(Mock(), _check=_check)
+        assert c._get_version_output() == ''
+
+    def test_output_usable(self):
+        version = 'ceph version 9.0.1-kjh234h123hd (asdf78asdjh234)'
+        _check = Mock(return_value=(version, '', 1))
+        c = packages.Ceph(Mock(), _check=_check)
+        assert c._get_version_output() == '9.0.1-kjh234h123hd'

--- a/ceph_deploy/util/packages.py
+++ b/ceph_deploy/util/packages.py
@@ -1,0 +1,59 @@
+from ceph_deploy.exc import ExecutableNotFound
+from ceph_deploy.util import system, versions
+from ceph_deploy.lib import remoto
+
+
+class Ceph(object):
+    """
+    Determine different aspects of the Ceph package, like ``version`` and path
+    ``executable``. Although mostly provide a version object that helps for
+    parsing and comparing.
+    """
+
+    def __init__(self, conn, _check=None):
+        self.conn = conn
+        self._check = _check or remoto.process.check
+
+    @property
+    def installed(self):
+        """
+        If the ``ceph`` executable exists, then Ceph is installed. Should
+        probably be revisited if different components do not have the ``ceph``
+        executable (this is currently provided by ``ceph-common``).
+        """
+        return bool(self.executable)
+
+    @property
+    def executable(self):
+        try:
+            return system.executable_path(self.conn, 'ceph')
+        except ExecutableNotFound:
+            return None
+
+    def _get_version_output(self):
+        """
+        Ignoring errors, call `ceph --version` and return only the version
+        portion of the output. For example, output like::
+
+            ceph version 9.0.1-1234kjd (asdflkj2k3jh234jhg)
+
+        Would return::
+
+            9.0.1-1234kjd
+        """
+        if not self.executable:
+            return ''
+        command = [self.executable, '--version']
+        out, _, _ = self._check(self.conn, command)
+        try:
+            return out.split()[2]
+        except IndexError:
+            return ''
+
+    @property
+    def version(self):
+        """
+        Return a version object (see
+        :mod:``ceph_deploy.util.versions.NormalizedVersion``)
+        """
+        return versions.parse_version(self._get_version_output)

--- a/ceph_deploy/util/packages.py
+++ b/ceph_deploy/util/packages.py
@@ -57,3 +57,18 @@ class Ceph(object):
         :mod:``ceph_deploy.util.versions.NormalizedVersion``)
         """
         return versions.parse_version(self._get_version_output)
+
+
+# callback helpers
+
+def ceph_is_installed(module):
+    """
+    A helper callback to be executed after the connection is made to ensure
+    that Ceph is installed.
+    """
+    ceph_package = Ceph(module.conn)
+    if not ceph_package.installed:
+        host = module.conn.hostname
+        raise RuntimeError(
+            'ceph needs to be installed in remote host: %s' % host
+        )

--- a/ceph_deploy/util/versions.py
+++ b/ceph_deploy/util/versions.py
@@ -1,0 +1,47 @@
+
+
+class NormalizedVersion(object):
+    """
+    A class to provide a clean interface for setting/retrieving distinct
+    version parts divided into major, minor, and patch (following convnetions
+    from semver (see http://semver.org/)
+
+    Since a lot of times version parts need to be compared, it provides for
+    `int` representations of their string counterparts, with some sanitization
+    processing.
+
+    Defaults to '0' or 0 (int) values when values are not set or parsing fails.
+    """
+
+    def __init__(self, raw_version):
+        self.raw_version = raw_version.strip()
+        self.major = '0'
+        self.minor = '0'
+        self.patch = '0'
+        self.garbage = ''
+        self.int_major = 0
+        self.int_minor = 0
+        self.int_patch = 0
+        self._version_map = {}
+        self._set_versions()
+
+    def _set_int_versions(self):
+        version_map = dict(
+            major=self.major,
+            minor=self.minor,
+            patch=self.patch,
+            garbage=self.garbage)
+
+        # safe int versions that remove non-numerical chars
+        # for example 'rc1' in a version like '1-rc1
+        for name, value in version_map.items():
+            if '-' in value:  # get rid of garbage like -dev1 or -rc1
+                value = value.split('-')[0]
+            value = float(''.join(c for c in value if c.isdigit()) or 0)
+            int_name = "int_%s" % name
+            setattr(self, int_name, value)
+
+    def _set_versions(self):
+        split_version = (self.raw_version.split('.') + ["0"]*4)[:4]
+        self.major, self.minor, self.patch, self.garbage = split_version
+        self._set_int_versions()


### PR DESCRIPTION
This is a PR with a bit of feature creep: the intent was to use the new `Ceph` object to provide an interface for versions and use it to map it against supported `systemd` versions.

It is not entirely sure if this approach will be used, but for now this can be used to fix (http://tracker.ceph.com/issues/11115) which allows to check if Ceph is installed and error accordingly. 

The "check if ceph is installed" comes free with this implementation, if we decide later to not use versions we can change the approach.

This PR also moves the private function in `hosts/__init__.py` to `util.versions` because the functionality is now being used by more than one place. At some point the tests should map to the new location - but all tests pass as it is now.