### PR TITLE
mon.py:

### DIFF
--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -420,7 +420,6 @@ def mon_create_initial(args):
             host,
             username=args.username,
             logger=rlogger,
-            callbacks=[packages.ceph_is_installed]
         )
 
         while tries:


### PR DESCRIPTION
callbacks arg to get_connection() has no matching parameter, raises
exception at end of "ceph-deploy mon create-initial".