### PR TITLE
use hosts.get() instead of get_connection for mon create-initial

### DIFF
--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -260,7 +260,11 @@ def mon_create(args):
         try:
             # TODO add_bootstrap_peer_hint
             LOG.debug('detecting platform for host %s ...', name)
-            distro = hosts.get(host, username=args.username, callbacks=[packages.ceph_is_installed])
+            distro = hosts.get(
+                host,
+                username=args.username,
+                callbacks=[packages.ceph_is_installed]
+            )
             LOG.info('distro info: %s %s %s', distro.name, distro.release, distro.codename)
             rlogger = logging.getLogger(name)
 


### PR DESCRIPTION
Originally reported by @blubanovic-penguin

the call to `get_connection()` was broken because of being passed a `callbacks` arg, which it didn't accept.

The way that callbacks were implemented in `hosts.get()` mandate that the callbacks be passed a `module` argument -- that module is the one returned (and determined by) `hosts.get()`.  This means that `get_connection` cannot be extended to take the same callbacks as `hosts.get()`.

But this is okay, because there doesn't seem to be a good reason for this function to use `get_connection`.  @alfredodeza mentioned in #346 that it used different defaults than `hosts.get()`, but looking at the source I don't see that being the case.

http://tracker.ceph.com/issues/12699