### PR TITLE
osd commands support "/dev/disk/by-path/".

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 import time
+import shlex
 from textwrap import dedent
 
 from cStringIO import StringIO
@@ -638,12 +639,26 @@ def colon_separated(s):
     journal = None
     disk = None
     host = None
-    if s.count(':') == 2:
-        (host, disk, journal) = s.split(':')
-    elif s.count(':') == 1:
-        (host, disk) = s.split(':')
-    elif s.count(':') == 0:
-        (host) = s
+    lexer = shlex.shlex(s)
+    lexer.whitespace = ':'
+    lexer.whitespace_split = True
+    splitline = []
+    try:
+        for token in lexer:
+            splitline.append(token.strip("'").strip('"'))
+    except ValueError, err:
+        first_line_of_error = lexer.token.splitlines()[0]
+        raise argparse.ArgumentTypeError(str(err) + ' following "' + first_line_of_error + '"')
+    splitline_len = len(splitline)
+    if splitline_len == 3:
+        host = splitline[0]
+        disk = splitline[1]
+        journal = splitline[2]
+    elif splitline_len == 2:
+        host = splitline[0]
+        disk = splitline[1]
+    elif splitline_len == 1:
+        host = splitline[0]
     else:
         raise argparse.ArgumentTypeError('must be in form HOST:DISK[:JOURNAL]')
 

--- a/ceph_deploy/tests/parser/test_disk.py
+++ b/ceph_deploy/tests/parser/test_disk.py
@@ -57,6 +57,38 @@ class TestParserDisk(object):
         out, err = capsys.readouterr()
         assert 'usage: ceph-deploy disk prepare' in out
 
+    def test_disk_prepare_disk(self):
+        args = self.parser.parse_args('disk prepare host1:/dev/sdb'.split())
+        assert args.disk[0][1] == '/dev/sdb'
+
+    def test_disk_prepare_disk_short(self):
+        args = self.parser.parse_args('disk prepare host1:sdb'.split())
+        assert args.disk[0][1] == '/dev/sdb'
+
+    def test_disk_prepare_disk_dquote(self):
+        args = self.parser.parse_args('disk prepare host1:"/dev/disk/by-path/pci-0000:00:1f.2-ata-1.0"'.split())
+        assert args.disk[0][1] == '/dev/disk/by-path/pci-0000:00:1f.2-ata-1.0'
+
+    def test_disk_prepare_disk_squote(self):
+        args = self.parser.parse_args("disk prepare host1:'/dev/disk/by-path/pci-0000:00:1f.2-ata-1.0'".split())
+        assert args.disk[0][1] == '/dev/disk/by-path/pci-0000:00:1f.2-ata-1.0'
+
+    def test_disk_prepare_journal(self):
+        args = self.parser.parse_args('disk prepare host1:/dev/sdb:/dev/sdc'.split())
+        assert args.disk[0][2] == '/dev/sdc'
+
+    def test_disk_prepare_journal_short(self):
+        args = self.parser.parse_args('disk prepare host1:sdb:sdc'.split())
+        assert args.disk[0][2] == '/dev/sdc'
+
+    def test_disk_prepare_journal_dquote(self):
+        args = self.parser.parse_args('disk prepare host1:"/dev/disk/by-path/pci-0000:00:1f.2-ata-1.0":"/dev/disk/by-path/pci-0000:00:1f.2-ata-2.0"'.split())
+        assert args.disk[0][2] == '/dev/disk/by-path/pci-0000:00:1f.2-ata-2.0'
+
+    def test_disk_prepare_journal_squote(self):
+        args = self.parser.parse_args("disk prepare host1:'/dev/disk/by-path/pci-0000:00:1f.2-ata-1.0':'/dev/disk/by-path/pci-0000:00:1f.2-ata-2.0'".split())
+        assert args.disk[0][2] == '/dev/disk/by-path/pci-0000:00:1f.2-ata-2.0'
+
     def test_disk_prepare_zap_default_false(self):
         args = self.parser.parse_args('disk prepare host1:sdb'.split())
         assert args.zap_disk is False


### PR DESCRIPTION
osd arguments can contain disk definitions by path.

/dev/disk/by-path/pci-0000:00:1f.2-ata-1.0

But these require : to delimit the host, disk and potentially journal.
Since argparse swallows \"' characters. But since \" and \' evaluate
to " and ' respectively we can use shlex to handle this correctly.

Hence a valid ceph-deploy command can now be:

```
ceph-deploy osd prepare --zap \
    ceph-node3:\'/dev/disk/by-path/pci-0000:00:1f.2-ata-1.0\'
```

or:

```
ceph-deploy osd prepare --zap \
    ceph-node3:\"/dev/disk/by-path/pci-0000:00:1f.2-ata-1.0\"
```

Signed-off-by: Owen Synge osynge@suse.com
