### PR TITLE
install: add --test install option to install ceph-test package

### DIFF
--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -56,6 +56,7 @@ def detect_components(args, distro):
         'install_mds': 'ceph-mds',
         'install_mon': 'ceph-mon',
         'install_common': 'ceph-common',
+        'install_tests': 'ceph-test',
     }
 
     if distro.is_rpm:
@@ -522,6 +523,13 @@ def make(parser):
     )
 
     parser.add_argument(
+        '--tests',
+        dest='install_tests',
+        action='store_true',
+        help='install the testing components',
+    )
+
+    parser.add_argument(
         '--cli', '--common',
         dest='install_common',
         action='store_true',
@@ -532,7 +540,7 @@ def make(parser):
         '--all',
         dest='install_all',
         action='store_true',
-        help='install all Ceph components (e.g. mon,osd,mds,rgw). This is the default',
+        help='install all Ceph components (mon, osd, mds, rgw) except tests. This is the default',
     )
 
     repo = parser.add_mutually_exclusive_group()

--- a/ceph_deploy/tests/test_install.py
+++ b/ceph_deploy/tests/test_install.py
@@ -48,6 +48,7 @@ class TestDetectComponents(object):
         self.args.install_mon = False
         self.args.install_osd = False
         self.args.install_rgw = False
+        self.args.install_tests = False
         self.args.install_common = False
         self.args.repo = False
         self.distro = Mock()
@@ -105,6 +106,11 @@ class TestDetectComponents(object):
         self.args.install_mds = True
         result = sorted(install.detect_components(self.args, self.distro))
         assert result == sorted(['ceph-osd', 'ceph-mds'])
+
+    def test_install_tests(self):
+        self.args.install_tests = True
+        result = sorted(install.detect_components(self.args, self.distro))
+        assert result == sorted(['ceph-test'])
 
     def test_install_all_should_be_default_when_no_options_passed(self):
         result = sorted(install.detect_components(self.args, self.distro))


### PR DESCRIPTION
We need this for the teuthology tests.

Don't include it in --all, since any normal person does not want it.

Signed-off-by: Sage Weil <sage@redhat.com>