### PR TITLE
[RM-12999] remove bootstrap-rgw key via forgetkeys

### DIFF
--- a/ceph_deploy/forgetkeys.py
+++ b/ceph_deploy/forgetkeys.py
@@ -14,6 +14,7 @@ def forgetkeys(args):
         'client.admin',
         'bootstrap-osd',
         'bootstrap-mds',
+        'bootstrap-rgw',
         ]:
         try:
             os.unlink('{cluster}.{what}.keyring'.format(


### PR DESCRIPTION
Fixes: #12999

Signed-off-by: Travis Rhoden <trhoden@redhat.com>