### PR TITLE
install --gitbuilder-host alternative to gitbuilder.ceph.com

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -89,11 +89,13 @@ def install(distro, version_kind, version, adjust_repos, **kw):
             logger.info('repo file will be created manually')
             mirror_install(
                 distro,
-                'http://gitbuilder.ceph.com/ceph-rpm-centos{release}-{machine}-basic/{sub}/{version}/'.format(
+                'http://{gitbuilder_host}/ceph-rpm-centos{release}-{machine}-basic/{sub}/{version}/'.format(
                     release=release.split(".", 1)[0],
                     machine=machine,
                     sub='ref' if version_kind == 'dev' else 'sha1',
-                    version=version),
+                    version=version,
+                    gitbuilder_host=kw['gitbuilder_host'],
+                ),
                 gpg.url(key),
                 adjust_repos=True,
                 extra_installs=False

--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -107,6 +107,10 @@ def install(distro, version_kind, version, adjust_repos, **kw):
         # set the right priority
         logger.warning('ensuring that /etc/yum.repos.d/ceph.repo contains a high priority')
         distro.conn.remote_module.set_repo_priority(['Ceph', 'Ceph-noarch', 'ceph-source'])
+        if kw['no_check_packages_signatures']:
+            distro.conn.remote_module.set_repo_gpgcheck(['Ceph', 'Ceph-noarch', 'ceph-source'],
+                                                        '/etc/yum.repos.d/ceph.repo',
+                                                        '0')
         logger.warning('altered ceph.repo priorities to contain: priority=1')
 
     if packages:

--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -36,11 +36,12 @@ def install(distro, version_kind, version, adjust_repos, **kw):
         elif version_kind == 'testing':
             url = 'http://download.ceph.com/debian-testing/'
         elif version_kind in ['dev', 'dev_commit']:
-            url = 'http://gitbuilder.ceph.com/ceph-deb-{codename}-{machine}-basic/{sub}/{version}'.format(
+            url = 'http://{gitbuilder_host}/ceph-deb-{codename}-{machine}-basic/{sub}/{version}'.format(
                 codename=codename,
                 machine=machine,
                 sub='ref' if version_kind == 'dev' else 'sha1',
                 version=version,
+                gitbuilder_host=kw['gitbuilder_host'],
                 )
         else:
             raise RuntimeError('Unknown version kind: %r' % version_kind)

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -66,14 +66,15 @@ def install(distro, version_kind, version, adjust_repos, **kw):
             logger.info('repo file will be created manually')
             mirror_install(
                 distro,
-                'http://gitbuilder.ceph.com/ceph-rpm-fc{release}-{machine}-basic/{sub}/{version}/'.format(
+                'http://{gitbuilder_host}/ceph-rpm-fc{release}-{machine}-basic/{sub}/{version}/'.format(
                     release=release.split(".", 1)[0],
                     machine=machine,
                     sub='ref' if version_kind == 'dev' else 'sha1',
                     version=version),
                 gpg.url(key),
                 adjust_repos=True,
-                extra_installs=False
+                extra_installs=False,
+                gitbuilder_host=kw['gitbuilder_host'],
             )
 
         else:

--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -65,17 +65,25 @@ def set_apt_priority(fqdn, path='/etc/apt/preferences.d/ceph.pref'):
 
 
 def set_repo_priority(sections, path='/etc/yum.repos.d/ceph.repo', priority='1'):
+    set_repo_key_value(sections, path, 'priority', priority)
+
+
+def set_repo_gpgcheck(sections, path='/etc/yum.repos.d/ceph.repo', gpgcheck='1'):
+    set_repo_key_value(sections, path, 'gpgcheck', gpgcheck)
+
+
+def set_repo_key_value(sections, path, key, value):
     Config = ConfigParser.ConfigParser()
     Config.read(path)
     Config.sections()
     for section in sections:
         try:
-            Config.set(section, 'priority', priority)
+            Config.set(section, key, value)
         except ConfigParser.NoSectionError:
             # Emperor versions of Ceph used all lowercase sections
             # so lets just try again for the section that failed, maybe
             # we are able to find it if it is lower
-            Config.set(section.lower(), 'priority', priority)
+            Config.set(section.lower(), key, value)
 
     with open(path, 'wb') as fout:
         Config.write(fout)

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -184,6 +184,7 @@ def install(args):
                 args.adjust_repos,
                 components=components,
                 gitbuilder_host=args.gitbuilder_host,
+                no_check_packages_signatures=args.no_check_packages_signatures,
             )
 
         # Check the ceph version we just installed
@@ -607,6 +608,12 @@ def make(parser):
         dest='gpg_url',
         help='specify a GPG key URL to be used with custom repos\
                 (defaults to ceph.com)'
+    )
+
+    repo.add_argument(
+        '--no-check-packages-signatures',
+        action='store_true',
+        help='do not check the package signatures',
     )
 
     parser.set_defaults(

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -183,6 +183,7 @@ def install(args):
                 version,
                 args.adjust_repos,
                 components=components,
+                gitbuilder_host=args.gitbuilder_host,
             )
 
         # Check the ceph version we just installed
@@ -589,6 +590,15 @@ def make(parser):
         nargs='?',
         dest='repo_url',
         help='specify a repo URL that mirrors/contains Ceph packages',
+    )
+
+    parser.add_argument(
+        '--gitbuilder-host',
+        nargs='?',
+        dest='gitbuilder_host',
+        default='gitbuilder.ceph.com',
+        help='specify a gitbuilder host that mirrors/contains Ceph packages,\
+                to use with --dev or --dev-commit exclusively.',
     )
 
     parser.add_argument(


### PR DESCRIPTION
To be used with --gitbuilder-host gitbuilder.myself.net
--dev-commit 6f11b82f3007819b58f143ad4b4911c4fb766ab9. It is primarily
useful in the context of the ceph_deploy.py task, when a full gitbuilder
mirror is available, with the exact same directory layout.

Signed-off-by: Loic Dachary <loic@dachary.org>