### PR TITLE
install --no-check-packages-signatures for test purposes

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -105,6 +105,10 @@ def install(distro, version_kind, version, adjust_repos, **kw):
         # set the right priority
         logger.warning('ensuring that /etc/yum.repos.d/ceph.repo contains a high priority')
         distro.conn.remote_module.set_repo_priority(['Ceph', 'Ceph-noarch', 'ceph-source'])
+        if kw['no_check_packages_signatures']:
+            distro.conn.remote_module.set_repo_gpgcheck(['Ceph', 'Ceph-noarch', 'ceph-source'],
+                                                        '/etc/yum.repos.d/ceph.repo',
+                                                        '0')
         logger.warning('altered ceph.repo priorities to contain: priority=1')
 
     if packages:

--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -27,7 +27,8 @@ def install(distro, version_kind, version, adjust_repos, **kw):
         protocol = 'https'
         if codename == 'wheezy':
             protocol = 'http'
-        distro.packager.add_repo_gpg_key(gpg.url(key, protocol=protocol))
+        if not kw['no_check_packages_signatures']:
+            distro.packager.add_repo_gpg_key(gpg.url(key, protocol=protocol))
 
         if version_kind == 'stable':
             url = 'http://download.ceph.com/debian-{version}/'.format(
@@ -54,9 +55,12 @@ def install(distro, version_kind, version, adjust_repos, **kw):
 
     # TODO this does not downgrade -- should it?
     if packages:
+        extra_install_flags=['-o', 'Dpkg::Options::=--force-confnew']
+        if kw['no_check_packages_signatures']:
+            extra_install_flags.append('--force-yes')
         distro.packager.install(
             packages,
-            extra_install_flags=['-o', 'Dpkg::Options::=--force-confnew']
+            extra_install_flags=extra_install_flags
         )
 
 

--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -65,17 +65,25 @@ def set_apt_priority(fqdn, path='/etc/apt/preferences.d/ceph.pref'):
 
 
 def set_repo_priority(sections, path='/etc/yum.repos.d/ceph.repo', priority='1'):
+    set_repo_key_value(sections, path, 'priority', priority)
+
+
+def set_repo_gpgcheck(sections, path='/etc/yum.repos.d/ceph.repo', gpgcheck='1'):
+    set_repo_key_value(sections, path, 'gpgcheck', gpgcheck)
+
+
+def set_repo_key_value(sections, path, key, value):
     Config = ConfigParser.ConfigParser()
     Config.read(path)
     Config.sections()
     for section in sections:
         try:
-            Config.set(section, 'priority', priority)
+            Config.set(section, key, value)
         except ConfigParser.NoSectionError:
             # Emperor versions of Ceph used all lowercase sections
             # so lets just try again for the section that failed, maybe
             # we are able to find it if it is lower
-            Config.set(section.lower(), 'priority', priority)
+            Config.set(section.lower(), key, value)
 
     with open(path, 'wb') as fout:
         Config.write(fout)

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -183,6 +183,7 @@ def install(args):
                 version,
                 args.adjust_repos,
                 components=components,
+                no_check_packages_signatures=args.no_check_packages_signatures,
             )
 
         # Check the ceph version we just installed
@@ -597,6 +598,12 @@ def make(parser):
         dest='gpg_url',
         help='specify a GPG key URL to be used with custom repos\
                 (defaults to ceph.com)'
+    )
+
+    parser.add_argument(
+        '--no-check-packages-signatures',
+        action='store_true',
+        help='do not check the package signatures',
     )
 
     parser.set_defaults(


### PR DESCRIPTION
http://tracker.ceph.com/issues/13249

When installing from repositories that are created dynamically within a
lab, verifying the packages signatures can be skipped. The
--no-check-packages-signatures configures the repositories to not
require package signatures verification during installation.

Signed-off-by: Loic Dachary <loic@dachary.org>