### PR TITLE
install --gitbuilder-host alternative to gitbuilder.ceph.com

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -89,11 +89,13 @@ def install(distro, version_kind, version, adjust_repos, **kw):
             logger.info('repo file will be created manually')
             mirror_install(
                 distro,
-                'http://gitbuilder.ceph.com/ceph-rpm-centos{release}-{machine}-basic/{sub}/{version}/'.format(
+                'http://{gitbuilder_host}/ceph-rpm-centos{release}-{machine}-basic/{sub}/{version}/'.format(
                     release=release.split(".", 1)[0],
                     machine=machine,
                     sub='ref' if version_kind == 'dev' else 'sha1',
-                    version=version),
+                    version=version,
+                    gitbuilder_host=kw['gitbuilder_host'],
+                ),
                 gpg.url(key),
                 adjust_repos=True,
                 extra_installs=False

--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -36,11 +36,12 @@ def install(distro, version_kind, version, adjust_repos, **kw):
         elif version_kind == 'testing':
             url = 'http://download.ceph.com/debian-testing/'
         elif version_kind in ['dev', 'dev_commit']:
-            url = 'http://gitbuilder.ceph.com/ceph-deb-{codename}-{machine}-basic/{sub}/{version}'.format(
+            url = 'http://{gitbuilder_host}/ceph-deb-{codename}-{machine}-basic/{sub}/{version}'.format(
                 codename=codename,
                 machine=machine,
                 sub='ref' if version_kind == 'dev' else 'sha1',
                 version=version,
+                gitbuilder_host=kw['gitbuilder_host'],
                 )
         else:
             raise RuntimeError('Unknown version kind: %r' % version_kind)

--- a/ceph_deploy/hosts/fedora/install.py
+++ b/ceph_deploy/hosts/fedora/install.py
@@ -66,14 +66,15 @@ def install(distro, version_kind, version, adjust_repos, **kw):
             logger.info('repo file will be created manually')
             mirror_install(
                 distro,
-                'http://gitbuilder.ceph.com/ceph-rpm-fc{release}-{machine}-basic/{sub}/{version}/'.format(
+                'http://{gitbuilder_host}/ceph-rpm-fc{release}-{machine}-basic/{sub}/{version}/'.format(
                     release=release.split(".", 1)[0],
                     machine=machine,
                     sub='ref' if version_kind == 'dev' else 'sha1',
                     version=version),
                 gpg.url(key),
                 adjust_repos=True,
-                extra_installs=False
+                extra_installs=False,
+                gitbuilder_host=kw['gitbuilder_host'],
             )
 
         else:

--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -183,6 +183,7 @@ def install(args):
                 version,
                 args.adjust_repos,
                 components=components,
+                gitbuilder_host=args.gitbuilder_host,
             )
 
         # Check the ceph version we just installed
@@ -589,6 +590,15 @@ def make(parser):
         nargs='?',
         dest='repo_url',
         help='specify a repo URL that mirrors/contains Ceph packages',
+    )
+
+    parser.add_argument(
+        '--gitbuilder-host',
+        nargs='?',
+        dest='gitbuilder_host',
+        default='gitbuilder.ceph.com',
+        help='specify a gitbuilder host that mirrors/contains Ceph packages,\
+                to use with --dev or --dev-commit exclusively.',
     )
 
     parser.add_argument(


### PR DESCRIPTION
To be used with --gitbuilder-host gitbuilder.myself.net
--dev-commit 6f11b82f3007819b58f143ad4b4911c4fb766ab9. It is primarily
useful in the context of the ceph_deploy.py task, when a full gitbuilder
mirror is available, with the exact same directory layout.

http://tracker.ceph.com/issues/13254 Fixes: #13254

Signed-off-by: Loic Dachary <loic@dachary.org>