### PR TITLE
[RM-13585] Add timestamp to console and log output

### DIFF
--- a/ceph_deploy/cli.py
+++ b/ceph_deploy/cli.py
@@ -149,7 +149,7 @@ def _main(args=None, namespace=None):
     # File Logger
     fh = logging.FileHandler('{cluster}.log'.format(cluster=args.cluster))
     fh.setLevel(logging.DEBUG)
-    fh.setFormatter(logging.Formatter(log.BASE_FORMAT))
+    fh.setFormatter(logging.Formatter(log.FILE_FORMAT))
 
     root_logger.addHandler(fh)
 

--- a/ceph_deploy/util/log.py
+++ b/ceph_deploy/util/log.py
@@ -17,7 +17,7 @@ RESET_SEQ = "\033[0m"
 COLOR_SEQ = "\033[1;%dm"
 BOLD_SEQ = "\033[1m"
 
-BASE_COLOR_FORMAT = "[%(timestamp)s][$BOLD%(name)s$RESET][%(color_levelname)-17s] %(message)s"
+BASE_COLOR_FORMAT = "[$BOLD%(name)s$RESET][%(color_levelname)-17s] %(message)s"
 BASE_FORMAT = "[%(timestamp)s][%(name)s][%(levelname)-6s] %(message)s"
 
 

--- a/ceph_deploy/util/log.py
+++ b/ceph_deploy/util/log.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import datetime
 
 BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
 
@@ -16,8 +17,8 @@ RESET_SEQ = "\033[0m"
 COLOR_SEQ = "\033[1;%dm"
 BOLD_SEQ = "\033[1m"
 
-BASE_COLOR_FORMAT = "[$BOLD%(name)s$RESET][%(color_levelname)-17s] %(message)s"
-BASE_FORMAT = "[%(name)s][%(levelname)-6s] %(message)s"
+BASE_COLOR_FORMAT = "[%(timestamp)s][$BOLD%(name)s$RESET][%(color_levelname)-17s] %(message)s"
+BASE_FORMAT = "[%(timestamp)s][%(name)s][%(levelname)-6s] %(message)s"
 
 
 def supports_color():
@@ -53,6 +54,7 @@ class ColoredFormatter(logging.Formatter):
         truncated_level = record.levelname[:6]
         levelname_color = COLOR_SEQ % (30 + COLORS[levelname]) + truncated_level + RESET_SEQ
         record.color_levelname = levelname_color
+        record.timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
         return logging.Formatter.format(self, record)
 
 

--- a/ceph_deploy/util/log.py
+++ b/ceph_deploy/util/log.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-import datetime
 
 BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
 
@@ -18,8 +17,8 @@ COLOR_SEQ = "\033[1;%dm"
 BOLD_SEQ = "\033[1m"
 
 BASE_COLOR_FORMAT = "[$BOLD%(name)s$RESET][%(color_levelname)-17s] %(message)s"
-BASE_FORMAT = "[%(timestamp)s][%(name)s][%(levelname)-6s] %(message)s"
-
+BASE_FORMAT = "[%(name)s][%(levelname)-6s] %(message)s"
+FILE_FORMAT = "[%(asctime)s]" + BASE_FORMAT
 
 def supports_color():
     """
@@ -54,7 +53,6 @@ class ColoredFormatter(logging.Formatter):
         truncated_level = record.levelname[:6]
         levelname_color = COLOR_SEQ % (30 + COLORS[levelname]) + truncated_level + RESET_SEQ
         record.color_levelname = levelname_color
-        record.timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
         return logging.Formatter.format(self, record)
 
 


### PR DESCRIPTION
An Example of the output here:
```
ceph-deploy gatherkeys mon1
[2015-11-23 11:55:09.049981][ceph_deploy.conf][DEBUG ] found configuration file at: /home/vagrant/.cephdeploy.conf
[2015-11-23 11:55:09.050858][ceph_deploy.cli][INFO  ] Invoked (1.5.28): /home/vagrant/bin/ceph-deploy gatherkeys mon1
[2015-11-23 11:55:09.051282][ceph_deploy.cli][INFO  ] ceph-deploy options:
[2015-11-23 11:55:09.051730][ceph_deploy.cli][INFO  ]  username                      : None
[2015-11-23 11:55:09.052110][ceph_deploy.cli][INFO  ]  verbose                       : False
```

I'm happy to discuss my proposed solution. 

For tracker see: http://tracker.ceph.com/issues/13585
