### PR TITLE
[RM-14049] deal with systemd when stopping a mon otherwise raise an error

### DIFF
--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -7,7 +7,7 @@ import time
 from ceph_deploy import conf, exc, admin
 from ceph_deploy.cliutil import priority
 from ceph_deploy.util.help_formatters import ToggleRawTextHelpFormatter
-from ceph_deploy.util import paths, net, files, packages
+from ceph_deploy.util import paths, net, files, packages, system
 from ceph_deploy.lib import remoto
 from ceph_deploy.new import new_mon_keyring
 from ceph_deploy import hosts
@@ -344,6 +344,14 @@ def destroy_mon(conn, cluster, hostname):
                 'status',
                 'mon.{hostname}'.format(hostname=hostname),
             ]
+        elif system.is_systemd(conn):
+            status_args = [
+                'systemctl',
+                'stop',
+                'ceph-mon@{hostname}.service'.format(hostname=hostname),
+            ]
+        else:
+            raise RuntimeError('unsupported init system detected, cannot continue')
 
         while retries:
             conn.logger.info('polling the daemon to verify it stopped')


### PR DESCRIPTION
Issue tracker http://tracker.ceph.com/issues/14049
Signed-off-by: Alfredo Deza <adeza@redhat.com>

Successful output looks like this for a systemd box:

    ...
    [ceph_deploy.mon][DEBUG ] Removing mon from node4
    [node4][DEBUG ] connection detected need for sudo
    [node4][DEBUG ] connected to host: node4
    [node4][DEBUG ] detect platform information from remote host
    [node4][DEBUG ] detect machine type
    [node4][DEBUG ] find the location of an executable
    [node4][DEBUG ] get remote short hostname
    [node4][INFO  ] polling the daemon to verify it stopped
    [node4][INFO  ] Running command: sudo service ceph status mon.node4
    [node4][INFO  ] Running command: sudo mkdir -p /var/lib/ceph/mon-removed
    [node4][DEBUG ] move old monitor data
