### PR TITLE
[RM-13909] bump requirement for remoto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.environ.get('CEPH_DEPLOY_NO_VENDOR'):
     clean_vendor('remoto')
 else:
     vendorize([
-        ('remoto', '0.0.25', ['python', 'vendor.py']),
+        ('remoto', '0.0.26', ['python', 'vendor.py']),
     ])
 
 


### PR DESCRIPTION
fixes http://tracker.ceph.com/issues/13909

With the following commit:
https://github.com/alfredodeza/remoto/commit/f9c8e87a8e3fc48bd122c86953ec87ac1be13a10

remoto 0.0.26 is now released

/cc @ktdreyer 