### PR TITLE
[RM-14355] Remove "filestore xattr use omap = true"

### DIFF
--- a/ceph_deploy/new.py
+++ b/ceph_deploy/new.py
@@ -190,9 +190,6 @@ def new(args):
     cfg.set('global', 'auth service required', 'cephx')
     cfg.set('global', 'auth client required', 'cephx')
 
-    # http://tracker.newdream.net/issues/3138
-    cfg.set('global', 'filestore xattr use omap', 'true')
-
     path = '{name}.conf'.format(
         name=args.cluster,
         )

--- a/ceph_deploy/tests/test_cli_new.py
+++ b/ceph_deploy/tests/test_cli_new.py
@@ -68,4 +68,3 @@ def test_defaults(newcfg):
     assert cfg.get('global', 'auth cluster required') == 'cephx'
     assert cfg.get('global', 'auth service required') == 'cephx'
     assert cfg.get('global', 'auth client required') == 'cephx'
-    assert cfg.get('global', 'filestore_xattr_use_omap') == 'true'


### PR DESCRIPTION
This patch removes option "filestore_xattr_use_omap"
from default ceph.conf global section,
as this option was removed in #7408.

Cleanup #14355

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>