### PR TITLE
[RM-13847] Using full paths to executables

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -107,8 +107,9 @@ def osd_status_check(conn, cluster):
     Note how the booleans are actually strings, so we need to take that into
     account and fix it before returning the dictionary. Issue #8108
     """
+    ceph_executable = system.executable_path(conn, 'ceph')
     command = [
-        'ceph',
+        ceph_executable,
         '--cluster={cluster}'.format(cluster=cluster),
         'osd',
         'stat',
@@ -191,8 +192,9 @@ def prepare_disk(
     """
     Run on osd node, prepares a data disk for use.
     """
+    ceph_disk_executable = system.executable_path(conn, 'ceph-disk')
     args = [
-        'ceph-disk',
+        ceph_disk_executable,
         '-v',
         'prepare',
         ]
@@ -362,11 +364,12 @@ def activate(args, cfg):
 
         LOG.debug('activating host %s disk %s', hostname, disk)
         LOG.debug('will use init type: %s', distro.init)
-
+        
+        ceph_disk_executable = system.executable_path(distro.conn, 'ceph-disk')
         remoto.process.run(
             distro.conn,
             [
-                'ceph-disk',
+                ceph_disk_executable,
                 '-v',
                 'activate',
                 '--mark-init',

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -427,10 +427,11 @@ def disk_zap(args):
         if distro.normalized_name.startswith(('centos', 'red')):
             LOG.info('calling partx on zapped device %s', disk)
             LOG.info('re-reading known partitions will display errors')
+            partx_executable = system.executable_path(distro.conn, 'partx')
             remoto.process.run(
                 distro.conn,
                 [
-                    'partx',
+                    partx_executable,
                     '-a',
                     disk,
                 ],
@@ -438,10 +439,11 @@ def disk_zap(args):
 
         else:
             LOG.debug('Calling partprobe on zapped device %s', disk)
+            partprobe_executable = system.executable_path(distro.conn, 'partprobe')
             remoto.process.run(
                 distro.conn,
                 [
-                    'partprobe',
+                    partprobe_executable,
                     disk,
                 ],
             )


### PR DESCRIPTION
Refactored out some direct executable calls in "osd.py". 

Should we do that for all executable calls in ceph-deploy?

For tracker see: http://tracker.ceph.com/issues/13847