### PR TITLE
Init fallback for upstart

### DIFF
--- a/ceph_deploy/hosts/debian/__init__.py
+++ b/ceph_deploy/hosts/debian/__init__.py
@@ -2,6 +2,7 @@ import mon  # noqa
 from install import install, mirror_install, repo_install  # noqa
 from uninstall import uninstall  # noqa
 from ceph_deploy.util import pkg_managers
+from ceph_deploy.util.system import is_systemd, is_upstart
 
 # Allow to set some information about this distro
 #
@@ -10,17 +11,20 @@ distro = None
 release = None
 codename = None
 
+
 def choose_init(module):
     """
     Select a init system
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
-    # fixme: newer ubuntu runs systemd
-    if distro.lower() == 'ubuntu':
-        return 'upstart'
-    if module.conn.remote_module.path_exists("/lib/systemd/system/ceph.target"):
+    if is_systemd(module.conn) or module.conn.remote_module.path_exists(
+            "/lib/systemd/system/ceph.target"):
         return 'systemd'
+
+    if is_upstart(module.conn):
+        return 'upstart'
+
     return 'sysvinit'
 
 

--- a/ceph_deploy/mon.py
+++ b/ceph_deploy/mon.py
@@ -328,7 +328,7 @@ def destroy_mon(conn, cluster, hostname):
         )
 
         # stop
-        if conn.remote_module.path_exists(os.path.join(path, 'upstart')):
+        if conn.remote_module.path_exists(os.path.join(path, 'upstart')) or system.is_upstart(conn):
             status_args = [
                 'initctl',
                 'status',
@@ -351,7 +351,7 @@ def destroy_mon(conn, cluster, hostname):
                 'ceph-mon@{hostname}.service'.format(hostname=hostname),
             ]
         else:
-            raise RuntimeError('unsupported init system detected, cannot continue')
+            raise RuntimeError('could not detect a supported init system, cannot continue')
 
         while retries:
             conn.logger.info('polling the daemon to verify it stopped')


### PR DESCRIPTION
So that we are able to fallback sensibly to detect upstart and make it easier on systems where monitors weren't added by ceph-deploy.

https://bugzilla.redhat.com/show_bug.cgi?id=1282484