### PR TITLE
[RM-15112] Rename ceph-deploy log file to ceph-deploy-${CLUSTER}.log

### DIFF
--- a/ceph_deploy/cli.py
+++ b/ceph_deploy/cli.py
@@ -147,7 +147,7 @@ def _main(args=None, namespace=None):
     sh.setLevel(console_loglevel)
 
     # File Logger
-    fh = logging.FileHandler('{cluster}.log'.format(cluster=args.cluster))
+    fh = logging.FileHandler('ceph-deploy-{cluster}.log'.format(cluster=args.cluster))
     fh.setLevel(logging.DEBUG)
     fh.setFormatter(logging.Formatter(log.FILE_FORMAT))
 


### PR DESCRIPTION
This patch renames ceph-deploy log file to ceph-deploy-${CLUSTER}.log

Fixes: #15112

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>