### PR TITLE
Fix the function name of osd keyring creation

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -30,7 +30,7 @@ def get_bootstrap_osd_key(cluster):
         raise RuntimeError('bootstrap-osd keyring not found; run \'gatherkeys\'')
 
 
-def create_osd(conn, cluster, key):
+def create_osd_keyring(conn, cluster, key):
     """
     Run on osd node, writes the bootstrap key if not there yet.
     """
@@ -307,7 +307,7 @@ def prepare(args, cfg, activate_prepared_disk):
                     args.overwrite_conf
                 )
 
-                create_osd(distro.conn, args.cluster, key)
+                create_osd_keyring(distro.conn, args.cluster, key)
 
             LOG.debug('Preparing host %s disk %s journal %s activate %s',
                       hostname, disk, journal, activate_prepared_disk)


### PR DESCRIPTION
http://tracker.ceph.com/issues/15409
Change the function name "create_osd" to "create_osd_keyring".
This function just do:
1. Check the remote node's osd keyring exist or not
2. If not, it create one.
The original name would confused the developers.

Signed-off-by: DesmondS <jordanjimmy41177@gmail.com>