### PR TITLE
Fix rsync username when using local_mirror

### DIFF
--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -147,6 +147,8 @@ def install(args):
             gpg_url = gpg_fallback
 
         if args.local_mirror:
+            if args.username:
+                hostname = "%s@%s" % (args.username, hostname)
             remoto.rsync(hostname, args.local_mirror, '/opt/ceph-deploy/repo', distro.conn.logger, sudo=True)
             repo_url = 'file:///opt/ceph-deploy/repo'
             gpg_url = 'file:///opt/ceph-deploy/repo/release.asc'


### PR DESCRIPTION
We should use the configured username for rsync to connect
to the remote host.

Signed-off-by: Wanlong Gao <wanlong.gao@easystack.cn>