### PR TITLE
Do not use sudo in rsync

### DIFF
--- a/ceph_deploy/install.py
+++ b/ceph_deploy/install.py
@@ -149,7 +149,7 @@ def install(args):
         if args.local_mirror:
             if args.username:
                 hostname = "%s@%s" % (args.username, hostname)
-            remoto.rsync(hostname, args.local_mirror, '/opt/ceph-deploy/repo', distro.conn.logger, sudo=True)
+            remoto.rsync(hostname, args.local_mirror, '/opt/ceph-deploy/repo', distro.conn.logger, sudo=False)
             repo_url = 'file:///opt/ceph-deploy/repo'
             gpg_url = 'file:///opt/ceph-deploy/repo/release.asc'
 


### PR DESCRIPTION
Got the error with:

	[node-1][INFO  ] installing Ceph on node-1
	sudo: sorry, you must have a tty to run sudo

Seems that the rsync do not have a tty to run sudo, so
do not use sudo here and just ensure that the user has
permission to sync the packages to the right location.

Signed-off-by: Wanlong Gao <wanlong.gao@easystack.cn>