### PR TITLE
modify sysvinit if condition

### DIFF
--- a/ceph_deploy/hosts/centos/__init__.py
+++ b/ceph_deploy/hosts/centos/__init__.py
@@ -21,7 +21,7 @@ def choose_init(module):
     if module.normalized_release.int_major < 7:
         return 'sysvinit'
 
-    if not module.conn.remote_module.path_exists("/usr/lib/systemd/system/ceph.target"):
+    if not module.conn.remote_module.path_exists("/usr/lib/systemd"):
         return 'sysvinit'
 
     return 'systemd'


### PR DESCRIPTION
If ceph packages aren't installed on the host with systemd preinstalled, script will return sysvinit instead of systemd which is invalid.