### PR TITLE
[RM-16651] Installs `diamond` while executing `ceph-deploy calamari c…

### DIFF
--- a/ceph_deploy/calamari.py
+++ b/ceph_deploy/calamari.py
@@ -57,6 +57,7 @@ def connect(args):
         )
 
         distro.packager.install('salt-minion')
+        distro.packager.install('diamond')
 
         # redhat/centos need to get the service started
         if distro.normalized_name in ['redhat', 'centos']:


### PR DESCRIPTION
[RM-16651] Installs `diamond` while executing `ceph-deploy calamari connect`.

Fixes http://tracker.ceph.com/issues/16651

`ceph-deploy calamari connect` does not install `diamond`.

This patch tries to fix it by calling `distro.pkg.install()`
for `diamond`.

Signed-off-by: Vimal <arvimal@yahoo.in>