### PR TITLE
Cleanup unneeded requirements

### DIFF
--- a/ceph-deploy.spec
+++ b/ceph-deploy.spec
@@ -20,19 +20,14 @@ URL:            http://ceph.com/
 Source0:        %{name}-%{version}.tar.bz2
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python-devel
-BuildRequires:  python-distribute
 BuildRequires:  python-setuptools
-BuildRequires:  python-virtualenv
 BuildRequires:  python-mock
-BuildRequires:  python-tox
 %if 0%{?suse_version}
 BuildRequires:  python-pytest
 %else
 BuildRequires:  pytest
 %endif
 BuildRequires:  git
-Requires:       python-argparse
-Requires:       python-distribute
 #Requires:      lsb-release
 #Requires:      ceph
 %if 0%{?suse_version} && 0%{?suse_version} <= 1110


### PR DESCRIPTION
python-distribute conflicts with setuptools and is deprecated.
Moreover we don't run unit test at build time
