### PR TITLE
Add --cluster arg as required to two commands

### DIFF
--- a/ceph_deploy/hosts/common.py
+++ b/ceph_deploy/hosts/common.py
@@ -116,6 +116,7 @@ def mon_add(distro, args, monitor_keyring):
             distro.conn,
             [
                 'ceph',
+                '--cluster', args.cluster,
                 'mon',
                 'getmap',
                 '-o',
@@ -158,6 +159,7 @@ def mon_add(distro, args, monitor_keyring):
         distro.conn,
         [
             'ceph-mon',
+            '--cluster', args.cluster,
             '-i',
             hostname,
             '--pid-file', pid_location,


### PR DESCRIPTION
When running ceph-deploy --cluster <name> mon add <host> failure occurs due to the following two commands being run by ceph-deploy without the --cluster <name> arg:

ceph mon getmap -o /var/lib/ceph/tmp/vpm1.vpm1-osd1.monmap
ceph-mon -i vpm1-osd1 --pid-file /var/run/ceph/mon.vpm1-osd1.pid --public-addr 192.168.99.49

This breaks ceph-deploy's ability to add monitors to a non-default named cluster.
More info at http://tracker.ceph.com/issues/17238

This commit adds the two arg lines to fix this.

I apologise if I haven't follow the correct procedure with this, it's my first contribution to Ceph.