### PR TITLE
Rm 18035,rm 18034,rm 18033,rm 18032,rm 18031,rm 18029,rm 18028

### DIFF
--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -152,6 +152,10 @@ def rgw_create(args):
     # Update the config file
     changed_cfg = False
     for hostname, name in args.rgw:
+        if not name.startswith('rgw.'):
+            msg = "rgw name '%s' does not start with 'rgw.'" % (name)
+            LOG.error(msg)
+            raise RuntimeError(msg)
         enitity = 'client.{name}'.format(name=name)
         port = 7480
         if cfg.has_section(enitity) is False:
@@ -250,10 +254,9 @@ def rgw(args):
 
 def colon_separated(s):
     host = s
-    name = s
+    name = 'rgw.' + s
     if s.count(':') == 1:
         (host, name) = s.split(':')
-    name = 'rgw.' + name
     return (host, name)
 
 

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -152,13 +152,12 @@ def rgw_create(args):
 
     # Update the config file
     changed_cfg = False
-    for hostname, name in args.rgw:
+    for hostname, name, port in args.rgw:
         if not name.startswith('rgw.'):
             msg = "rgw name '%s' does not start with 'rgw.'" % (name)
             LOG.error(msg)
             raise RuntimeError(msg)
         enitity = 'client.{name}'.format(name=name)
-        port = 7480
         if cfg.has_section(enitity) is False:
             cfg.add_section(enitity)
             changed_cfg = True
@@ -174,7 +173,6 @@ def rgw_create(args):
                 msg = "exisiting rgw '%s:%s' has a different hostname" % (hostname, name)
                 LOG.error(msg)
                 raise RuntimeError(msg)
-
         if cfg.has_option(enitity,'rgw_dns_name') is False:
             cfg.set(enitity, 'rgw_dns_name', hostname)
             changed_cfg = True
@@ -206,7 +204,7 @@ def rgw_create(args):
         with open(cfg_path, 'wb') as configfile:
             cfg.write(configfile)
 
-    for hostname, name in args.rgw:
+    for hostname, name, port in args.rgw:
         try:
             distro = hosts.get(hostname, username=args.username)
             rlogger = distro.conn.logger
@@ -240,9 +238,9 @@ def rgw_create(args):
             distro.conn.exit()
             LOG.info(
                 ('The Ceph Object Gateway (RGW) is now running on host %s and '
-                 'default port %s'),
+                 'port %s'),
                 hostname,
-                '7480'
+                port
             )
         except RuntimeError as e:
             LOG.error(e)
@@ -321,9 +319,8 @@ def rgw_delete(args):
 
     # Check if config needs to be changed
     changed_cfg = False
-    for hostname, name in args.rgw:
+    for hostname, name, port in args.rgw:
         enitity = 'client.{name}'.format(name=name)
-        port = 7480
         if cfg.has_section(enitity) is True:
             cfg.remove_section(enitity)
             changed_cfg = True
@@ -337,7 +334,8 @@ def rgw_delete(args):
             raise RuntimeError(msg)
 
     changed_cfg = False
-    for hostname, name in args.rgw:
+
+    for hostname, name, port in args.rgw:
         try:
             distro = hosts.get(hostname, username=args.username)
             LOG.info(
@@ -377,7 +375,7 @@ def rgw_delete(args):
         with open(cfg_path, 'wb') as configfile:
             cfg.write(configfile)
         # now distribute
-        for hostname, name in args.rgw:
+        for hostname, name, port in args.rgw:
             try:
                 distro = hosts.get(hostname, username=args.username)
                 LOG.info(
@@ -414,10 +412,14 @@ def rgw(args):
 def colon_separated(s):
     host = s
     name = 'rgw.' + s
-    if s.count(':') == 1:
+    port = '7480'
+    delimiter_count = s.count(':')
+    if delimiter_count == 1:
         (host, name) = s.split(':')
+    if delimiter_count == 2:
+        (host, name, port) = s.split(':')
     name = validate.alphanumeric(name)
-    return (host, name)
+    return (host, name, port)
 
 
 @priority(30)
@@ -433,11 +435,10 @@ def make(parser):
         )
     rgw_create.add_argument(
         'rgw',
-        metavar='HOST[:NAME]',
+        metavar='HOST[:NAME][:PORT]',
         nargs='+',
         type=colon_separated,
-        help='host (and optionally the daemon name) to deploy on. \
-                NAME is automatically prefixed with \'rgw.\'',
+        help='host (and optionally the daemon name and port) to deploy on.',
         )
     rgw_parser.add_parser(
         'list',

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -8,6 +8,7 @@ from ceph_deploy import hosts
 from ceph_deploy.util import system
 from ceph_deploy.lib import remoto
 from ceph_deploy.cliutil import priority
+from ceph_deploy import validate
 
 
 LOG = logging.getLogger(__name__)
@@ -394,6 +395,7 @@ def colon_separated(s):
     name = 'rgw.' + s
     if s.count(':') == 1:
         (host, name) = s.split(':')
+    name = validate.alphanumeric(name)
     return (host, name)
 
 

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -418,7 +418,7 @@ def colon_separated(s):
         (host, name) = s.split(':')
     if delimiter_count == 2:
         (host, name, port) = s.split(':')
-    name = validate.alphanumeric(name)
+    name = validate.alphanumericdot(name)
     return (host, name, port)
 
 

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -229,10 +229,14 @@ def rgw_create(args):
 def rgw_list(args):
     cfg = conf.ceph.load(args)
     for rgw_section in cfg.sections():
-        if not rgw_section.startswith('client.rgw'):
-            continue
         host = cfg.safe_get(rgw_section, 'host')
-        entity = rgw_section[7:]
+        entity = None
+        if rgw_section.startswith('client.rgw'):
+            entity = rgw_section[7:]
+        if rgw_section.startswith('client.radosgw.'):
+            entity = rgw_section[7:]
+        if entity is None:
+            continue
         print ("{host}:{entity}".format(host=host, entity=entity))
 
 

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -137,7 +137,7 @@ def create_rgw(distro, name, cluster, init):
 
 
 def rgw_create(args):
-    conf_data = conf.ceph.load_raw(args)
+    cfg = conf.ceph.load(args)
     LOG.debug(
         'Deploying rgw, cluster %s hosts %s',
         args.cluster,
@@ -148,6 +148,38 @@ def rgw_create(args):
 
     bootstrapped = set()
     errors = 0
+
+    # Update the config file
+    changed_cfg = False
+    for hostname, name in args.rgw:
+        enitity = 'client.{name}'.format(name=name)
+        port = 7480
+        if cfg.has_section(enitity) is False:
+            cfg.add_section(enitity)
+            changed_cfg = True
+        if cfg.has_option(enitity,'host') is False:
+            cfg.set(enitity, 'host', hostname)
+            changed_cfg = True
+        if cfg.has_option(enitity,'rgw_dns_name') is False:
+            # TODO this should be customizable
+            value = "%s:%s" % (hostname,port)
+            cfg.set(enitity, 'rgw_dns_name', hostname)
+            changed_cfg = True
+        if cfg.has_option(enitity,'rgw frontends') is False:
+            # TODO this should be customizable
+            cfg.set(enitity, 'rgw frontends', "civetweb port=%s" % (port))
+            changed_cfg = True
+
+    # If config file is changed save changes locally
+    if changed_cfg is True:
+        cfg_path = args.ceph_conf or '{cluster}.conf'.format(cluster=args.cluster)
+        if args.overwrite_conf is False:
+            msg = "The local config file '%s' exists with content that must be changed; use --overwrite-conf to update" % (cfg_path)
+            LOG.error(msg)
+            raise RuntimeError(msg)
+        with open(cfg_path, 'wb') as configfile:
+            cfg.write(configfile)
+
     for hostname, name in args.rgw:
         try:
             distro = hosts.get(hostname, username=args.username)
@@ -163,6 +195,7 @@ def rgw_create(args):
             if hostname not in bootstrapped:
                 bootstrapped.add(hostname)
                 LOG.debug('deploying rgw bootstrap to %s', hostname)
+                conf_data = conf.ceph.load_raw(args)
                 distro.conn.remote_module.write_conf(
                     args.cluster,
                     conf_data,

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -226,11 +226,22 @@ def rgw_create(args):
         raise exc.GenericError('Failed to create %d RGWs' % errors)
 
 
+def rgw_list(args):
+    cfg = conf.ceph.load(args)
+    for rgw_section in cfg.sections():
+        if not rgw_section.startswith('client.rgw'):
+            continue
+        host = cfg.safe_get(rgw_section, 'host')
+        entity = rgw_section[7:]
+        print ("{host}:{entity}".format(host=host, entity=entity))
+
+
 def rgw(args):
     if args.subcommand == 'create':
-        rgw_create(args)
-    else:
-        LOG.error('subcommand %s not implemented', args.subcommand)
+        return rgw_create(args)
+    if args.subcommand == 'list':
+        return rgw_list(args)
+    LOG.error('subcommand %s not implemented', args.subcommand)
 
 
 def colon_separated(s):
@@ -260,6 +271,10 @@ def make(parser):
         type=colon_separated,
         help='host (and optionally the daemon name) to deploy on. \
                 NAME is automatically prefixed with \'rgw.\'',
+        )
+    rgw_parser.add_parser(
+        'list',
+        help='list all rgw instances in local config'
         )
     parser.set_defaults(
         func=rgw,

--- a/ceph_deploy/rgw.py
+++ b/ceph_deploy/rgw.py
@@ -162,18 +162,39 @@ def rgw_create(args):
         if cfg.has_section(enitity) is False:
             cfg.add_section(enitity)
             changed_cfg = True
+        else:
+            # We have existing confg for the rgw
+            LOG.warning("existing configuration for rgw %s:%s" % (hostname, name))
         if cfg.has_option(enitity,'host') is False:
             cfg.set(enitity, 'host', hostname)
             changed_cfg = True
+        else:
+            existing_value = cfg.get(enitity, 'host')
+            if existing_value != hostname:
+                msg = "exisiting rgw '%s:%s' has a different hostname" % (hostname, name)
+                LOG.error(msg)
+                raise RuntimeError(msg)
+
         if cfg.has_option(enitity,'rgw_dns_name') is False:
-            # TODO this should be customizable
-            value = "%s:%s" % (hostname,port)
             cfg.set(enitity, 'rgw_dns_name', hostname)
             changed_cfg = True
+        else:
+            existing_value = cfg.get(enitity, 'rgw_dns_name')
+            if existing_value != hostname:
+                msg = "exisiting rgw '%s:%s' has a different rgw_dns_name" % (hostname, name)
+                LOG.error(msg)
+                raise RuntimeError(msg)
+        rgw_frontends_value = "civetweb port=%s" % (port)
         if cfg.has_option(enitity,'rgw frontends') is False:
             # TODO this should be customizable
-            cfg.set(enitity, 'rgw frontends', "civetweb port=%s" % (port))
+            cfg.set(enitity, 'rgw frontends', rgw_frontends_value)
             changed_cfg = True
+        else:
+            existing_value = cfg.get(enitity, 'rgw frontends')
+            if existing_value != rgw_frontends_value:
+                msg = "exisiting rgw '%s:%s' has a different 'rgw frontends'" % (hostname, name)
+                LOG.error(msg)
+                raise RuntimeError(msg)
 
     # If config file is changed save changes locally
     if changed_cfg is True:

--- a/ceph_deploy/tests/test_cli_rgw.py
+++ b/ceph_deploy/tests/test_cli_rgw.py
@@ -8,4 +8,4 @@ def test_rgw_prefix_auto():
 
 def test_rgw_prefix_custom():
     daemon = rgw.colon_separated("hostname:mydaemon")
-    assert daemon == ("hostname", "rgw.mydaemon")
+    assert daemon == ("hostname", "mydaemon")

--- a/ceph_deploy/tests/test_cli_rgw.py
+++ b/ceph_deploy/tests/test_cli_rgw.py
@@ -3,9 +3,14 @@ import ceph_deploy.rgw as rgw
 
 def test_rgw_prefix_auto():
     daemon = rgw.colon_separated("hostname")
-    assert daemon == ("hostname", "rgw.hostname")
+    assert daemon == ("hostname", "rgw.hostname", '7480')
 
 
 def test_rgw_prefix_custom():
     daemon = rgw.colon_separated("hostname:mydaemon")
-    assert daemon == ("hostname", "mydaemon")
+    assert daemon == ("hostname", "mydaemon", '7480')
+
+
+def test_rgw_prefix_custom_port():
+    daemon = rgw.colon_separated("hostname:mydaemon:7481")
+    assert daemon == ("hostname", "mydaemon", '7481')

--- a/ceph_deploy/validate.py
+++ b/ceph_deploy/validate.py
@@ -3,6 +3,7 @@ import re
 
 
 ALPHANUMERIC_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9]*$')
+ALPHANUMERICDOT_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9\.]*$')
 
 
 def alphanumeric(s):
@@ -12,5 +13,15 @@ def alphanumeric(s):
     if not ALPHANUMERIC_RE.match(s):
         raise argparse.ArgumentTypeError(
             'argument must start with a letter and contain only letters and numbers',
+            )
+    return s
+
+def alphanumericdot(s):
+    """
+    Enforces string to be alphanumeric and dot allowed with leading alpha.
+    """
+    if not ALPHANUMERICDOT_RE.match(s):
+        raise argparse.ArgumentTypeError(
+            'argument must start with a letter and contain only letters and numbers or dot',
             )
     return s

--- a/ceph_deploy/validate.py
+++ b/ceph_deploy/validate.py
@@ -3,7 +3,7 @@ import re
 
 
 ALPHANUMERIC_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9]*$')
-ALPHANUMERICDOT_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9\.]*$')
+ALPHANUMERICDOT_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9\.\-\_]*$')
 
 
 def alphanumeric(s):
@@ -22,6 +22,6 @@ def alphanumericdot(s):
     """
     if not ALPHANUMERICDOT_RE.match(s):
         raise argparse.ArgumentTypeError(
-            'argument must start with a letter and contain only letters and numbers or dot',
+            'argument must start with a letter and contain only letters and numbers or [.-_]',
             )
     return s


### PR DESCRIPTION
This is a set of downstream work to deal with issues:

1. #18028 rgw cannot define custom port
2. #18029 rgw does not provide a way to delete configured services.
3. #18031 rgw does not provide a way to list rgw services.
4. #18032 rgw option does not specify the dns hostname in the config file.
5. #18033 rgw does not specify the front end in the config file.
6. #18034 rgw takes Czech characters as service name then fails.
7. #18035 rgw should not default the name when users may have a good reason to specify non defaulted name.

 Signed-off-by: Owen Synge <osynge@suse.com>