### PR TITLE
Allow unsigned deb packages install from mirror locations

### DIFF
--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -76,6 +76,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
 
 def mirror_install(distro, repo_url, gpg_url, adjust_repos, **kw):
     packages = kw.pop('components', [])
+    version_kind = kw['args'].version_kind
     repo_url = repo_url.strip('/')  # Remove trailing slashes
 
     if adjust_repos:
@@ -87,9 +88,13 @@ def mirror_install(distro, repo_url, gpg_url, adjust_repos, **kw):
 
         distro.conn.remote_module.write_sources_list(repo_url, distro.codename)
 
+    extra_install_flags = ['--allow-unauthenticated'] if version_kind in 'dev' else []
+
     if packages:
         distro.packager.clean()
-        distro.packager.install(packages)
+        distro.packager.install(
+            packages,
+            extra_install_flags=extra_install_flags)
 
 
 def repo_install(distro, repo_name, baseurl, gpgkey, **kw):


### PR DESCRIPTION
In a test deployment, hosting ceph packages in a local mirror and
installing them across the cluster will be ideal. Current ceph-deploy
allows unauthenticated packages when install is used but not from a
mirror location. This change helps address that usecase.

Signed-off-by: Ganesh Mahalingam <ganesh.mahalingam@intel.com>