### PR TITLE
Add cluster as an argument for osd activate

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -379,6 +379,8 @@ def activate(args, cfg):
                 'activate',
                 '--mark-init',
                 distro.init,
+                '--cluster',
+                args.cluster,
                 '--mount',
                 disk,
             ],


### PR DESCRIPTION
With recent changes in ceph (https://github.com/ceph/ceph/pull/11786),
this change will allow ceph-deploy osd activate to complete without
errors. Follow-on fix for http://tracker.ceph.com/issues/17821

Signed-off-by: Ganesh Mahalingam <ganesh.mahalingam@intel.com>