### PR TITLE
fix UnboundLocalError

### DIFF
--- a/ceph_deploy/hosts/debian/install.py
+++ b/ceph_deploy/hosts/debian/install.py
@@ -14,6 +14,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
     packages = kw.pop('components', [])
     codename = distro.codename
     machine = distro.machine_type
+    extra_install_flags = []
 
     if version_kind in ['stable', 'testing']:
         key = 'release'


### PR DESCRIPTION
If ceph-ceph_deploy is called with:
  'install node1 --no-adjust-repos --nogpgcheck'
python trace shows this error:
  UnboundLocalError: local variable 'extra_install_flags'
  referenced before assignment

Signed-off-by: Danny Al-Gaaf <danny.al-gaaf@bisect.de>