### PR TITLE
[RM-17287] hosts: detect systemd before sysvinit in centos

### DIFF
--- a/ceph_deploy/hosts/centos/__init__.py
+++ b/ceph_deploy/hosts/centos/__init__.py
@@ -22,11 +22,11 @@ def choose_init(module):
     if module.normalized_release.int_major < 7:
         return 'sysvinit'
 
-    if not module.conn.remote_module.path_exists("/usr/lib/systemd/system/ceph.target"):
-        return 'sysvinit'
-
     if is_systemd(module.conn):
         return 'systemd'
+
+    if not module.conn.remote_module.path_exists("/usr/lib/systemd/system/ceph.target"):
+        return 'sysvinit'
 
     return 'systemd'
 


### PR DESCRIPTION
Reference isssue: http://tracker.ceph.com/issues/17287