### PR TITLE
[RM-19301] add Virtuozzo Linux support

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -66,9 +66,9 @@ def get(hostname,
     module.normalized_name = _normalized_distro_name(distro_name)
     module.normalized_release = _normalized_release(release)
     module.distro = module.normalized_name
-    module.is_el = module.normalized_name in ['redhat', 'centos', 'fedora', 'scientific', 'oracle']
+    module.is_el = module.normalized_name in ['redhat', 'centos', 'fedora', 'scientific', 'oracle', 'virtuozzo']
     module.is_rpm = module.normalized_name in ['redhat', 'centos',
-                                               'fedora', 'scientific', 'suse', 'oracle']
+                                               'fedora', 'scientific', 'suse', 'oracle', 'virtuozzo']
     module.is_deb = not module.is_rpm
     module.release = release
     module.codename = codename
@@ -97,6 +97,7 @@ def _get_distro(distro, fallback=None, use_rhceph=False):
         'redhat': centos,
         'fedora': fedora,
         'suse': suse,
+        'virtuozzo' : centos
         }
 
     if distro == 'redhat' and use_rhceph:
@@ -119,6 +120,8 @@ def _normalized_distro_name(distro):
         return 'centos'
     elif distro.startswith('linuxmint'):
         return 'ubuntu'
+    elif distro.startswith('virtuozzo'):
+        return 'virtuozzo'
     return distro
 
 

--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -11,7 +11,7 @@ NON_SPLIT_PACKAGES = ['ceph-osd', 'ceph-mon', 'ceph-mds']
 
 
 def rpm_dist(distro):
-    if distro.normalized_name in ['redhat', 'centos', 'scientific', 'oracle'] and distro.normalized_release.int_major >= 6:
+    if distro.normalized_name in ['redhat', 'centos', 'scientific', 'oracle', 'virtuozzo'] and distro.normalized_release.int_major >= 6:
         return 'el' + distro.normalized_release.major
     return 'el6'
 
@@ -35,7 +35,7 @@ def repository_url_part(distro):
     if distro.normalized_release.int_major >= 6:
         if distro.normalized_name == 'redhat':
             return 'rhel' + distro.normalized_release.major
-        if distro.normalized_name in ['centos', 'scientific', 'oracle']:
+        if distro.normalized_name in ['centos', 'scientific', 'oracle', 'virtuozzo']:
             return 'el' + distro.normalized_release.major
 
     return 'el6'

--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -33,6 +33,8 @@ def platform_information(_linux_distribution=None):
                 codename = major
     if not codename and 'oracle' in distro.lower(): # this could be an empty string in Oracle linux
         codename = 'oracle'
+    if not codename and 'virtuozzo linux' in distro.lower(): # this could be an empty string in Virtuozzo linux
+        codename = 'virtuozzo'
 
     return (
         str(distro).rstrip(),

--- a/ceph_deploy/tests/unit/hosts/test_hosts.py
+++ b/ceph_deploy/tests/unit/hosts/test_hosts.py
@@ -31,6 +31,10 @@ class TestNormalized(object):
         result = hosts._normalized_distro_name('RedHatEnterpriseLinux')
         assert result == 'redhat'
 
+    def test_get_virtuozzo(self):
+        result = hosts._normalized_distro_name('Virtuozzo Linux')
+        assert result == 'virtuozzo'
+
 
 class TestNormalizeRelease(object):
 
@@ -411,3 +415,7 @@ class TestGetDistro(object):
     def test_get_mint(self):
         result = hosts._get_distro('LinuxMint')
         assert result.__name__.endswith('debian')
+
+    def test_get_virtuozzo(self):
+        result = hosts._get_distro('Virtuozzo Linux')
+        assert result.__name__.endswith('centos')


### PR DESCRIPTION
Virtuozzo Linux based on CentOS and got the same major release number and empty codename.

import platform
platform.linux_distribution()
('Virtuozzo Linux', '7.3', '')