### PR TITLE
mgr: update osd and mds caps

### DIFF
--- a/ceph_deploy/mgr.py
+++ b/ceph_deploy/mgr.py
@@ -49,6 +49,8 @@ def create_mgr(distro, name, cluster, init):
             '--keyring', bootstrap_keyring,
             'auth', 'get-or-create', 'mgr.{name}'.format(name=name),
             'mon', 'allow profile mgr',
+            'osd', 'allow *',
+            'mds', 'allow *',
             '-o',
             os.path.join(keypath),
         ]


### PR DESCRIPTION
This is to enable mgr daemons to remote control
mds and osd daemons using MCommand messages.

Fixes: http://tracker.ceph.com/issues/19713
Signed-off-by: John Spray <john.spray@redhat.com>