### PR TITLE
remove custom cluster names for deploying

### DIFF
--- a/ceph_deploy/cli.py
+++ b/ceph_deploy/cli.py
@@ -69,12 +69,6 @@ def get_parser():
         help='overwrite an existing conf file on remote host (if present)',
         )
     parser.add_argument(
-        '--cluster',
-        metavar='NAME',
-        help='name of the cluster',
-        type=validate.alphanumeric,
-        )
-    parser.add_argument(
         '--ceph-conf',
         dest='ceph_conf',
         help='use (or reuse) a given ceph.conf file',

--- a/ceph_deploy/tests/parser/test_main.py
+++ b/ceph_deploy/tests/parser/test_main.py
@@ -65,17 +65,6 @@ class TestParserMain(object):
         args = self.parser.parse_args('forgetkeys'.split())
         assert args.cluster == 'ceph'
 
-    def test_custom_cluster_name(self):
-        args = self.parser.parse_args('--cluster myhugecluster forgetkeys'.split())
-        assert args.cluster == 'myhugecluster'
-
-    def test_custom_cluster_name_bad(self, capsys):
-        with pytest.raises(SystemExit):
-            self.parser.parse_args('--cluster=/evil-this-should-not-be-created'.split())
-        out, err = capsys.readouterr()
-        assert ('--cluster: argument must start with a letter and contain only '
-                'letters and numbers') in err
-
     def test_default_ceph_conf_is_none(self):
         args = self.parser.parse_args('forgetkeys'.split())
         assert args.ceph_conf is None


### PR DESCRIPTION
It still uses 'ceph' everywhere but disables this customization 

http://tracker.ceph.com/issues/20228