### PR TITLE
[RM-22712] Use recursive dir creation

### DIFF
--- a/ceph_deploy/mgr.py
+++ b/ceph_deploy/mgr.py
@@ -32,7 +32,7 @@ def create_mgr(distro, name, cluster, init):
         name=name
         )
 
-    conn.remote_module.safe_mkdir(path)
+    conn.remote_module.safe_makedirs(path)
 
     bootstrap_keyring = '/var/lib/ceph/bootstrap-mgr/{cluster}.keyring'.format(
         cluster=cluster


### PR DESCRIPTION
If `/var/lib/ceph/mgr` directory is missing, `safe_mkdir` still does not fail, but subsequent code is unable to reach `/var/lib/ceph/mgr/cluster-hostname` directory, which will not be created (as `mgr` folder is missing)

This is formatted under contribution guidelines, as noted in #458.

Link to redmine issue: [22712](http://tracker.ceph.com/issues/22712)