### PR TITLE
[RM-22816] osd use logger.info to get the output on disk list

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -373,7 +373,7 @@ def disk_list(args, cfg):
         )
         for line in out:
             if line.startswith('Disk /'):
-                distro.conn.logger(line)
+                distro.conn.logger.info(line)
 
 
 def osd_list(args, cfg):


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/22816

Before:

    (ceph-deploy) papaya-2 ~/tmp/foo ᓆ ceph-deploy disk list node8
    [ceph_deploy.conf][DEBUG ] found configuration file at: /Users/alfredo/tmp/foo/cephdeploy.conf
    [ceph_deploy.cli][INFO  ] Invoked (2.0.0): /Users/alfredo/.virtualenvs/ceph-deploy/bin/ceph-deploy disk list node8
    [ceph_deploy.cli][INFO  ] ceph-deploy options:
    [ceph_deploy.cli][INFO  ]  username                      : None
    [ceph_deploy.cli][INFO  ]  verbose                       : False
    [ceph_deploy.cli][INFO  ]  debug                         : False
    [ceph_deploy.cli][INFO  ]  overwrite_conf                : False
    [ceph_deploy.cli][INFO  ]  subcommand                    : list
    [ceph_deploy.cli][INFO  ]  quiet                         : False
    [ceph_deploy.cli][INFO  ]  cd_conf                       : <ceph_deploy.conf.cephdeploy.Conf object at 0x10ce145d0>
    [ceph_deploy.cli][INFO  ]  cluster                       : ceph
    [ceph_deploy.cli][INFO  ]  host                          : ['node8']
    [ceph_deploy.cli][INFO  ]  func                          : <function disk at 0x10cde4a28>
    [ceph_deploy.cli][INFO  ]  ceph_conf                     : None
    [ceph_deploy.cli][INFO  ]  default_release               : False
    [node8][DEBUG ] connection detected need for sudo
    [node8][DEBUG ] connected to host: node8
    [node8][DEBUG ] detect platform information from remote host
    [node8][DEBUG ] detect machine type
    [node8][DEBUG ] find the location of an executable
    [node8][INFO  ] Running command: sudo fdisk -l
    [ceph_deploy][ERROR ] Traceback (most recent call last):
    [ceph_deploy][ERROR ]   File "/Users/alfredo/python/upstream/ceph-deploy/ceph_deploy/util/decorators.py", line 69, in newfunc
    [ceph_deploy][ERROR ]     return f(*a, **kw)
    [ceph_deploy][ERROR ]   File "/Users/alfredo/python/upstream/ceph-deploy/ceph_deploy/cli.py", line 164, in _main
    [ceph_deploy][ERROR ]     return args.func(args)
    [ceph_deploy][ERROR ]   File "/Users/alfredo/python/upstream/ceph-deploy/ceph_deploy/osd.py", line 434, in disk
    [ceph_deploy][ERROR ]     disk_list(args, cfg)
    [ceph_deploy][ERROR ]   File "/Users/alfredo/python/upstream/ceph-deploy/ceph_deploy/osd.py", line 376, in disk_list
    [ceph_deploy][ERROR ]     distro.conn.logger(line)
    [ceph_deploy][ERROR ] TypeError: 'Logger' object is not callable
    [ceph_deploy][ERROR ]


After:

    (ceph-deploy) papaya-2 ~/tmp/foo ᓆ ceph-deploy disk list node8
    [ceph_deploy.conf][DEBUG ] found configuration file at: /Users/alfredo/tmp/foo/cephdeploy.conf
    [ceph_deploy.cli][INFO  ] Invoked (2.0.0): /Users/alfredo/.virtualenvs/ceph-deploy/bin/ceph-deploy disk list node8
    [ceph_deploy.cli][INFO  ] ceph-deploy options:
    [ceph_deploy.cli][INFO  ]  username                      : None
    [ceph_deploy.cli][INFO  ]  verbose                       : False
    [ceph_deploy.cli][INFO  ]  debug                         : False
    [ceph_deploy.cli][INFO  ]  overwrite_conf                : False
    [ceph_deploy.cli][INFO  ]  subcommand                    : list
    [ceph_deploy.cli][INFO  ]  quiet                         : False
    [ceph_deploy.cli][INFO  ]  cd_conf                       : <ceph_deploy.conf.cephdeploy.Conf object at 0x1036d55d0>
    [ceph_deploy.cli][INFO  ]  cluster                       : ceph
    [ceph_deploy.cli][INFO  ]  host                          : ['node8']
    [ceph_deploy.cli][INFO  ]  func                          : <function disk at 0x1036a5a28>
    [ceph_deploy.cli][INFO  ]  ceph_conf                     : None
    [ceph_deploy.cli][INFO  ]  default_release               : False
    [node8][DEBUG ] connection detected need for sudo
    [node8][DEBUG ] connected to host: node8
    [node8][DEBUG ] detect platform information from remote host
    [node8][DEBUG ] detect machine type
    [node8][DEBUG ] find the location of an executable
    [node8][INFO  ] Running command: sudo fdisk -l
    [node8][INFO  ] Disk /dev/ram0: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram1: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram2: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram3: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram4: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram5: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram6: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram7: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram8: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram9: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram10: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram11: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram12: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram13: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram14: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/ram15: 64 MiB, 67108864 bytes, 131072 sectors
    [node8][INFO  ] Disk /dev/sda: 300 GiB, 322122547200 bytes, 629145600 sectors
    [node8][INFO  ] Disk /dev/mapper/ubuntubox--vg-root: 297.5 GiB, 319450775552 bytes, 623927296 sectors
    [node8][INFO  ] Disk /dev/mapper/ubuntubox--vg-swap_1: 2 GiB, 2143289344 bytes, 4186112 sectors
