### PR TITLE
[RM-23218] fix UnboundLocalError when create mds/mgr with bad hosts

### DIFF
--- a/ceph_deploy/mds.py
+++ b/ceph_deploy/mds.py
@@ -139,6 +139,7 @@ def mds_create(args):
 
     for hostname, name in args.mds:
         try:
+            distro = None
             distro = hosts.get(hostname, username=args.username)
             rlogger = distro.conn.logger
             LOG.info(
@@ -170,7 +171,7 @@ def mds_create(args):
             create_mds(distro, name, args.cluster, distro.init)
             distro.conn.exit()
         except RuntimeError as e:
-            if distro.normalized_name == 'redhat':
+            if distro and distro.normalized_name == 'redhat':
                 LOG.error('this feature may not yet available for %s %s' % (distro.name, distro.release))
                 failed_on_rhel = True
             LOG.error(e)

--- a/ceph_deploy/mgr.py
+++ b/ceph_deploy/mgr.py
@@ -139,6 +139,7 @@ def mgr_create(args):
 
     for hostname, name in args.mgr:
         try:
+            distro = None
             distro = hosts.get(hostname, username=args.username)
             rlogger = distro.conn.logger
             LOG.info(
@@ -170,7 +171,7 @@ def mgr_create(args):
             create_mgr(distro, name, args.cluster, distro.init)
             distro.conn.exit()
         except RuntimeError as e:
-            if distro.normalized_name == 'redhat':
+            if distro and distro.normalized_name == 'redhat':
                 LOG.error('this feature may not yet available for %s %s' % (distro.name, distro.release))
                 failed_on_rhel = True
             LOG.error(e)


### PR DESCRIPTION
If we fail to get hostname, the hosts.get will raise an exception and
don't return any value, so the variable distro in [1] and [2] may be
undefined. What's worse, we may get previous value if we fail in second
time but succeed in first time.

In order to avoid the issues above, we should initialize the distro
value in each loop iteration.

[1] https://github.com/ceph/ceph-deploy/blob/master/ceph_deploy/mgr.py#L173
[2] https://github.com/ceph/ceph-deploy/blob/master/ceph_deploy/mds.py#L173