### PR TITLE
Fix remoto vendoring, bump remoto version to 0.0.35

### DIFF
--- a/ceph-deploy.spec
+++ b/ceph-deploy.spec
@@ -31,8 +31,7 @@ BuildRequires:  pytest
 %endif
 BuildRequires:  git
 Requires:       python-argparse
-#Requires:      lsb-release
-#Requires:      ceph
+Requires:       python-remoto
 %if 0%{?suse_version} && 0%{?suse_version} <= 1110
 %{!?python_sitelib: %global python_sitelib %(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 %else

--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Architecture: all
 Depends: python,
          python-argparse,
          python-setuptools,
+         python-remoto,
          ${misc:Depends},
          ${python:Depends}
 Description:  Ceph-deploy is an easy to use configuration tool

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup, find_packages
 import os
 import sys
 import ceph_deploy
-from vendor import vendorize, clean_vendor
 
 
 def read(fname):
@@ -10,22 +9,11 @@ def read(fname):
     f = open(path)
     return f.read()
 
-install_requires = []
+
+install_requires = ['remoto']
 pyversion = sys.version_info[:2]
 if pyversion < (2, 7) or (3, 0) <= pyversion <= (3, 1):
     install_requires.append('argparse')
-
-#
-# Add libraries that are not part of install_requires but only if we really
-# want to, specified by the environment flag
-#
-
-if os.environ.get('CEPH_DEPLOY_NO_VENDOR'):
-    clean_vendor('remoto')
-else:
-    vendorize([
-        ('remoto', '0.0.33', ['python', 'vendor.py']),
-    ])
 
 
 setup(


### PR DESCRIPTION
A change in the remoto version caused vendoring not to work anymore. We now declare our dependencies directly in Python, spec file, and control file.

Bumps remoto to use the latest version available (0.0.35 at this time) which fixes the following error:

    NameError: global name 'extend_path' is not defined

Fixes: http://tracker.ceph.com/issues/37848