### PR TITLE
Fix hard deprecation errors in tests

### DIFF
--- a/ceph_deploy/tests/conftest.py
+++ b/ceph_deploy/tests/conftest.py
@@ -87,7 +87,7 @@ class CLITester(object):
 
 
 @pytest.fixture
-def cli(request):
+def cli(request, tmpdir):
     """
     Test command line behavior.
     """
@@ -95,6 +95,4 @@ def cli(request):
     # the tmpdir here will be the same value as the test function
     # sees; we rely on that to let caller prepare and introspect
     # any files the cli tool will read or create
-    tmpdir = request.getfuncargvalue('tmpdir')
-
     return CLITester(tmpdir=tmpdir)

--- a/ceph_deploy/tests/test_cli_new.py
+++ b/ceph_deploy/tests/test_cli_new.py
@@ -24,8 +24,7 @@ def test_write_global_conf_section(tmpdir):
 
 
 @pytest.fixture
-def newcfg(request):
-    tmpdir = request.getfuncargvalue('tmpdir')
+def newcfg(request, tmpdir):
     fake_ip_addresses = lambda x: ['10.0.0.1']
 
     def new(*args):


### PR DESCRIPTION
Caused by new pytest version.

Fixes: http://tracker.ceph.com/issues/37939