### PR TITLE
test_altlinux: Remove print statement

### DIFF
--- a/ceph_deploy/tests/unit/hosts/test_altlinux.py
+++ b/ceph_deploy/tests/unit/hosts/test_altlinux.py
@@ -4,7 +4,6 @@ from ceph_deploy.hosts.alt.install import map_components, NON_SPLIT_PACKAGES
 class TestALTMapComponents(object):
     def test_valid(self):
         pkgs = map_components(NON_SPLIT_PACKAGES, ['ceph-osd', 'ceph-common', 'ceph-radosgw'])
-        print(pkgs)
         assert 'ceph' in pkgs
         assert 'ceph-common' in pkgs
         assert 'ceph-radosgw' in pkgs


### PR DESCRIPTION
The commit 6190bb2 introduced an unnecessary print statement in the
altlinux tests.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>