### PR TITLE
decode string of disk list fixed

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -372,6 +372,7 @@ def disk_list(args, cfg):
             command,
         )
         for line in out:
+            line = line.decode('utf-8')
             if line.startswith('Disk /'):
                 distro.conn.logger.info(line)
 


### PR DESCRIPTION
fixed error of decode string in disk_list function of osd.


` TypeError: startswith first arg must be bytes or a tuple of bytes, not str`

this patch solved this problem which happened in python3.(compatible with python2.7)