### PR TITLE
Enable ClearLinux as a supported distro

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -7,7 +7,7 @@ on the type of distribution/version we are dealing with.
 import logging
 from ceph_deploy import exc
 from ceph_deploy.util import versions
-from ceph_deploy.hosts import debian, centos, fedora, suse, remotes, rhel, arch, alt
+from ceph_deploy.hosts import debian, centos, fedora, suse, remotes, rhel, arch, alt, clear
 from ceph_deploy.connection import get_connection
 
 logger = logging.getLogger()
@@ -71,6 +71,7 @@ def get(hostname,
                                                'fedora', 'scientific', 'suse', 'oracle', 'virtuozzo', 'alt']
     module.is_deb = module.normalized_name in ['debian', 'ubuntu']
     module.is_pkgtarxz = module.normalized_name in ['arch']
+    module.is_swupd = module.normalized_name in ['clear']
     module.release = release
     module.codename = codename
     module.conn = conn
@@ -101,7 +102,8 @@ def _get_distro(distro, fallback=None, use_rhceph=False):
         'suse': suse,
         'virtuozzo': centos,
         'arch': arch,
-        'alt': alt
+        'alt': alt,
+        'clear': clear
         }
 
     if distro == 'redhat' and use_rhceph:
@@ -130,6 +132,8 @@ def _normalized_distro_name(distro):
         return 'arch'
     elif distro.startswith(('alt', 'altlinux', 'basealt', 'alt linux')):
         return 'alt'
+    elif distro.startswith('clear'):
+        return 'clear'
     return distro
 
 

--- a/ceph_deploy/hosts/clear/__init__.py
+++ b/ceph_deploy/hosts/clear/__init__.py
@@ -1,0 +1,25 @@
+from . import mon # noqa
+from .install import install # noqa
+from .uninstall import uninstall # noqa
+from ceph_deploy.util import pkg_managers
+
+# Allow to set some information about this distro
+#
+
+distro = None
+release = None
+codename = None
+
+
+def choose_init(module):
+    """
+    Select a init system
+
+    Returns the name of a init system (upstart, sysvinit ...).
+    """
+    # Currently clearlinux only has systemd.
+    return 'systemd'
+
+
+def get_packager(module):
+    return pkg_managers.Swupd(module)

--- a/ceph_deploy/hosts/clear/install.py
+++ b/ceph_deploy/hosts/clear/install.py
@@ -1,0 +1,14 @@
+
+def install(distro, version_kind, version, adjust_repos, **kw):
+    """
+    Install bundle that contains ceph on the clear host.
+
+    Since clear does not have alternate channels, we will just run the command
+    """
+    logger = distro.conn.logger
+    packages = ['storage-cluster']
+
+    logger.info("Installing storage-cluster bundle")
+    distro.packager.install(
+        packages
+        )

--- a/ceph_deploy/hosts/clear/mon/__init__.py
+++ b/ceph_deploy/hosts/clear/mon/__init__.py
@@ -1,0 +1,2 @@
+from ceph_deploy.hosts.common import mon_add as add  # noqa
+from ceph_deploy.hosts.common import mon_create as create  # noqa

--- a/ceph_deploy/hosts/clear/uninstall.py
+++ b/ceph_deploy/hosts/clear/uninstall.py
@@ -1,0 +1,42 @@
+import logging
+
+from ceph_deploy.util.system import disable_service, stop_service
+
+SYSTEMD_UNITS = [
+    'ceph-mds.target',
+    'ceph-mon.target',
+    'ceph-osd.target',
+    'ceph-radosgw.target',
+    'ceph-fuse.target',
+    'ceph-mgr.target',
+    'ceph-rbd-mirror.target',
+    'ceph.target',
+    'ceph-mds*service',
+    'ceph-mon*service',
+    'ceph-osd*service',
+    'ceph-radosgw*service',
+    'ceph-fuse*service',
+    'ceph-mgr*service',
+    'ceph-rbd-mirror*service',
+    'ceph*service',
+]
+
+
+def uninstall(distro, purge=False):
+
+    hostname = distro.conn.hostname
+    LOG = logging.getLogger(hostname)
+
+    # I need to stop and disable services prior package removal
+    LOG.info('stopping and disabling services on {}'.format(hostname))
+    for unit in SYSTEMD_UNITS:
+        stop_service(distro.conn, unit)
+        disable_service(distro.conn, unit)
+
+    packages = [
+        'storage-cluster',
+        'ceph'
+        ]
+
+    distro.packager.remove(packages)
+    distro.packager.clean()

--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -161,6 +161,10 @@ def write_conf(cluster, conf, overwrite):
     tmp_file = tempfile.NamedTemporaryFile('w', dir='/etc/ceph', delete=False)
     err_msg = 'config file %s exists with different content; use --overwrite-conf to overwrite' % path
 
+    if not os.path.isdir('/etc/ceph'):
+        err_msg = '/etc/ceph/ does not exist - could not write config'
+        raise RuntimeError(err_msg)
+
     if os.path.exists(path):
         with open(path, 'r') as f:
             old = f.read()
@@ -169,15 +173,10 @@ def write_conf(cluster, conf, overwrite):
         tmp_file.write(conf)
         tmp_file.close()
         shutil.move(tmp_file.name, path)
-        os.chmod(path, 0o644)
-        return
-    if os.path.exists('/etc/ceph'):
+    else:
         with open(path, 'w') as f:
             f.write(conf)
-        os.chmod(path, 0o644)
-    else:
-        err_msg = '/etc/ceph/ does not exist - could not write config'
-        raise RuntimeError(err_msg)
+    os.chmod(path, 0o644)
 
 
 def write_keyring(path, key, uid=-1, gid=-1):

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -427,3 +427,53 @@ class AptRpm(PackageManager):
     def clean(self):
         cmd = self.executable + ['update']
         return self._run(cmd)
+
+
+class Swupd(PackageManager):
+    """
+    Swupd package manager from ClearLinux distribution
+    """
+
+    executable = [
+        'swupd',
+        ]
+    name = 'swupd'
+
+    def install(self, packages, **kw):
+        if isinstance(packages, str):
+            packages = [packages]
+
+        extra_flags = kw.pop('extra_install_flags', None)
+        # Prior to installing packages, make sure we create folders for ceph
+        # config and logging which do not exist in Clear
+        cmd = ['mkdir', '-p', '/etc/ceph/']
+        self._run(cmd)
+        cmd = ['mkdir', '-p', '/var/log/ceph/']
+        self._run(cmd)
+
+        cmd = self.executable + ['bundle-add']
+
+        if extra_flags:
+            if isinstance(extra_flags, str):
+                extra_flags = [extra_flags]
+            cmd.extend(extra_flags)
+        cmd.extend(packages)
+        return self._run(cmd)
+
+    def remove(self, packages, **kw):
+        if isinstance(packages, str):
+            packages = [packages]
+
+        extra_flags = kw.pop('extra_remove_flags', None)
+        cmd = self.executable + ['bundle-remove']
+
+        if extra_flags:
+            if isinstance(extra_flags, str):
+                extra_flags = [extra_flags]
+            cmd.extend(extra_flags)
+        cmd.extend(packages)
+        return self._run(cmd)
+
+    def clean(self):
+        cmd = self.executable + ['clean']
+        return self._run(cmd)


### PR DESCRIPTION
This PR enables ClearLinux as a supported distribution with ceph-deploy. ClearLinux primarily only contains python3 which prompted another commit to add python3 support.