### PR TITLE
Add support for EulerOS

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -119,7 +119,7 @@ def _normalized_distro_name(distro):
         return 'oracle'
     elif distro.startswith(('suse', 'opensuse', 'sles')):
         return 'suse'
-    elif distro.startswith('centos'):
+    elif distro.startswith(('centos', 'euleros')):
         return 'centos'
     elif distro.startswith('linuxmint'):
         return 'ubuntu'


### PR DESCRIPTION
My server has installed Huawei EulerOS(v2.0sp8-arm64 Kunpeng920) and it's a client server in my ceph cluster. url:https://developer.huaweicloud.com/en-us/euleros/download.html?developlan=Other
[root@client12 ~]# cat /etc/os-release
NAME="EulerOS" 
VERSION="2.0 (SP5)" 
ID="euleros" 
ID_LIKE="rhel fedora centos" 
VERSION_ID="2.0" 
PRETTY_NAME="EulerOS 2.0 (SP5)" 
ANSI_COLOR="0;31"

When I use ceph-deploy commond to push ceph conf file to this client, I get following error:

root@node1:/etc/ceph# ceph-deploy --overwrite-conf config push client12
[ceph_deploy.conf][DEBUG ] found configuration file at: /root/.cephdeploy.conf
[ceph_deploy.cli][INFO ] Invoked (2.0.1): /usr/bin/ceph-deploy --overwrite-conf config push client12
[ceph_deploy.cli][INFO ] ceph-deploy options:
[ceph_deploy.cli][INFO ] username : None
[ceph_deploy.cli][INFO ] verbose : False
[ceph_deploy.cli][INFO ] overwrite_conf : True
[ceph_deploy.cli][INFO ] subcommand : push
[ceph_deploy.cli][INFO ] quiet : False
[ceph_deploy.cli][INFO ] cd_conf : <ceph_deploy.conf.cephdeploy.Conf instance at 0xffffb253d7a0>
[ceph_deploy.cli][INFO ] cluster : ceph
[ceph_deploy.cli][INFO ] client : ['client12']
[ceph_deploy.cli][INFO ] func : <function config at 0xffffb257ef50>
[ceph_deploy.cli][INFO ] ceph_conf : None
[ceph_deploy.cli][INFO ] default_release : False
[ceph_deploy.config][DEBUG ] Pushing config to client12
[client12][DEBUG ] connected to host: client12
[client12][DEBUG ] detect platform information from remote host
[ceph_deploy][ERROR ] UnsupportedPlatform: Platform is not supported: EulerOS SP5 2.0

After adding the euleros support in line 122, the error is fixed.
root@node1:/etc/ceph# ceph-deploy --overwrite-conf config push client12
[ceph_deploy.conf][DEBUG ] found configuration file at: /root/.cephdeploy.conf
[ceph_deploy.cli][INFO  ] Invoked (2.0.1): /usr/bin/ceph-deploy --overwrite-conf config push client12
[ceph_deploy.cli][INFO  ] ceph-deploy options:
[ceph_deploy.cli][INFO  ]  username                      : None
[ceph_deploy.cli][INFO  ]  verbose                       : False
[ceph_deploy.cli][INFO  ]  overwrite_conf                : True
[ceph_deploy.cli][INFO  ]  subcommand                    : push
[ceph_deploy.cli][INFO  ]  quiet                         : False
[ceph_deploy.cli][INFO  ]  cd_conf                       : <ceph_deploy.conf.cephdeploy.Conf instance at 0xffffaefd67e8>
[ceph_deploy.cli][INFO  ]  cluster                       : ceph
[ceph_deploy.cli][INFO  ]  client                        : ['client12']
[ceph_deploy.cli][INFO  ]  func                          : <function config at 0xffffaf017ed8>
[ceph_deploy.cli][INFO  ]  ceph_conf                     : None
[ceph_deploy.cli][INFO  ]  default_release               : False
[ceph_deploy.config][DEBUG ] Pushing config to client12
[client12][DEBUG ] connected to host: client12
[client12][DEBUG ] detect platform information from remote host
[client12][DEBUG ] detect machine type
[client12][DEBUG ] write cluster configuration to /etc/ceph/{cluster}.conf