### PR TITLE
Add support for EuroLinux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.pyc
 *.pyo
 *.egg-info
+/.eggs
 /build
 /dist
 build
@@ -20,3 +21,6 @@ build
 
 */lib/vendor/remoto
 remoto
+
+# Ignore all (Idea) PyCharm stuff
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 build
 
 /virtualenv
+/venv
 /.tox
 
 /ceph-deploy

--- a/bootstrap
+++ b/bootstrap
@@ -61,7 +61,7 @@ if ! [ -d virtualenv ]; then
 
     if [ -f /etc/redhat-release ]; then
         case "$(cat /etc/redhat-release | awk '{print $1}')" in
-        CentOS)
+        CentOS|EuroLinux)
             for package in python-virtualenv; do
                 if [ "$(rpm -qa "$package" 2>/dev/null)" == "" ]; then
                     missing="${missing:+$missing }$package"

--- a/ceph-deploy.spec
+++ b/ceph-deploy.spec
@@ -12,7 +12,7 @@
 #################################################################################
 Name:           ceph-deploy
 Version:       2.0.1
-Release:        0
+Release:        1
 Summary:        Admin and deploy tool for Ceph
 License:        MIT
 Group:          System/Filesystems

--- a/ceph-deploy.spec
+++ b/ceph-deploy.spec
@@ -12,7 +12,7 @@
 #################################################################################
 Name:           ceph-deploy
 Version:       2.0.1
-Release:        1
+Release:        2
 Summary:        Admin and deploy tool for Ceph
 License:        MIT
 Group:          System/Filesystems

--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -66,9 +66,10 @@ def get(hostname,
     module.normalized_name = _normalized_distro_name(distro_name)
     module.normalized_release = _normalized_release(release)
     module.distro = module.normalized_name
-    module.is_el = module.normalized_name in ['redhat', 'centos', 'fedora', 'scientific', 'oracle', 'virtuozzo']
-    module.is_rpm = module.normalized_name in ['redhat', 'centos',
-                                               'fedora', 'scientific', 'suse', 'oracle', 'virtuozzo', 'alt']
+    module.is_el = module.normalized_name in ['redhat', 'centos', 'fedora', 'scientific', 'oracle', 'virtuozzo',
+                                              'eurolinux']
+    module.is_rpm = module.normalized_name in ['redhat', 'centos', 'fedora', 'scientific', 'suse', 'oracle',
+                                               'virtuozzo', 'alt', 'eurolinux']
     module.is_deb = module.normalized_name in ['debian', 'ubuntu']
     module.is_pkgtarxz = module.normalized_name in ['arch']
     module.release = release
@@ -100,7 +101,8 @@ def _get_distro(distro, fallback=None, use_rhceph=False):
         'suse': suse,
         'virtuozzo': centos,
         'arch': arch,
-        'alt': alt
+        'alt': alt,
+        'eurolinux': centos,
         }
 
     if distro == 'redhat' and use_rhceph:
@@ -129,6 +131,8 @@ def _normalized_distro_name(distro):
         return 'arch'
     elif distro.startswith(('alt', 'altlinux', 'basealt', 'alt linux')):
         return 'alt'
+    elif distro.startswith('eurolinux'):
+        return 'eurolinux'
     return distro
 
 

--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -11,7 +11,8 @@ NON_SPLIT_PACKAGES = ['ceph-osd', 'ceph-mon', 'ceph-mds']
 
 
 def rpm_dist(distro):
-    if distro.normalized_name in ['redhat', 'centos', 'scientific', 'oracle', 'virtuozzo'] and distro.normalized_release.int_major >= 6:
+    if distro.normalized_name in ['redhat', 'centos', 'scientific', 'oracle', 'virtuozzo', 'eurolinux'] \
+            and distro.normalized_release.int_major >= 6:
         return 'el' + distro.normalized_release.major
     return 'el6'
 
@@ -35,7 +36,7 @@ def repository_url_part(distro):
     if distro.normalized_release.int_major >= 6:
         if distro.normalized_name == 'redhat':
             return 'rhel' + distro.normalized_release.major
-        if distro.normalized_name in ['centos', 'scientific', 'oracle', 'virtuozzo']:
+        if distro.normalized_name in ['centos', 'scientific', 'oracle', 'virtuozzo', 'eurolinux']:
             return 'el' + distro.normalized_release.major
 
     return 'el6'

--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -38,6 +38,8 @@ def platform_information(_linux_distribution=None):
                 codename = major
     if not codename and 'oracle' in distro.lower():  # this could be an empty string in Oracle linux
         codename = 'oracle'
+    if not codename and 'eurolinux' in distro.lower():
+        codename = 'eurolinux'
     if not codename and 'virtuozzo linux' in distro.lower():  # this could be an empty string in Virtuozzo linux
         codename = 'virtuozzo'
     if not codename and 'arch' in distro.lower():  # this could be an empty string in Arch linux

--- a/ceph_deploy/tests/unit/hosts/test_hosts.py
+++ b/ceph_deploy/tests/unit/hosts/test_hosts.py
@@ -35,6 +35,10 @@ class TestNormalized(object):
         result = hosts._normalized_distro_name('Virtuozzo Linux')
         assert result == 'virtuozzo'
 
+    def test_get_eurolinux(self):
+        result = hosts._normalized_distro_name('EuroLinux')
+        assert result == 'eurolinux'
+
     def test_get_arch(self):
         result = hosts._normalized_distro_name('Arch Linux')
         assert result == 'arch'
@@ -431,3 +435,7 @@ class TestGetDistro(object):
     def test_get_altlinux(self):
         result = hosts._get_distro('ALT Linux')
         assert result.__name__.endswith('alt')
+
+    def test_get_eurolinux(self):
+        result = hosts._get_distro('EuroLinux')
+        assert result.__name__.endswith('centos')


### PR DESCRIPTION
Signed-off-by: Alex Baranowski <alex@euro-linux.com>

This PR contains the patch that enables ceph-deploy on EuroLinux. I tested on both CentOS (in case of Ceph deploy EuroLinux uses CentOS like installation etc.) and EuroLinux.

Unfortunately on the **current master** some tests fail.

For Python 2.7:

- test_section_repeat()

Final result 
```
1 failed, 2027 passed, 16 skipped, 39 warnings in 17.20 seconds
```

For Python 3.6:

- test_executable_is_used(self)
- test_host_is_used(self)

Final result:
```
2 failed, 2026 passed, 16 skipped, 46 warnings in 15.82s
```

#### After patch

After the patch **the previous tests**, that are not connected with
the patch also fail, but the new tests work seamlessly, that means
that there is no regression.

I also change .gitignore, so PyCharm and .eggs files are ignored. 

I also noticed that there is half-finished CI on jenkins.ceph.com, I'm currently working on our in-house QA process, so if there is public repo, I could help with it.
