### PR TITLE
Support kylin os to deploy ceph cluster through ceph-deploy

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -121,7 +121,7 @@ def _normalized_distro_name(distro):
         return 'suse'
     elif distro.startswith(('centos', 'euleros')):
         return 'centos'
-    elif distro.startswith('linuxmint'):
+    elif distro.startswith(('linuxmint', 'kylin')):
         return 'ubuntu'
     elif distro.startswith('virtuozzo'):
         return 'virtuozzo'


### PR DESCRIPTION
I want to deploy or manage ceph via ceph-deploy on Kylin OS.

1. Unsupported OS reported during execution:
```
root@slave1:/tmp# ceph-deploy uninstall slave1
[ceph_deploy.conf][DEBUG ] found configuration file at: /root/.cephdeploy.conf
[ceph_deploy.cli][INFO  ] Invoked (2.0.1): /usr/bin/ceph-deploy uninstall slave1
[ceph_deploy.cli][INFO  ] ceph-deploy options:
[ceph_deploy.cli][INFO  ]  username                      : None
[ceph_deploy.cli][INFO  ]  verbose                       : False
[ceph_deploy.cli][INFO  ]  overwrite_conf                : False
[ceph_deploy.cli][INFO  ]  quiet                         : False
[ceph_deploy.cli][INFO  ]  cd_conf                       : <ceph_deploy.conf.cephdeploy.Conf instance at 0x7f91c9e170>
[ceph_deploy.cli][INFO  ]  cluster                       : ceph
[ceph_deploy.cli][INFO  ]  host                          : ['slave1']
[ceph_deploy.cli][INFO  ]  func                          : <function uninstall at 0x7f91e2fb18>
[ceph_deploy.cli][INFO  ]  ceph_conf                     : None
[ceph_deploy.cli][INFO  ]  default_release               : False
[ceph_deploy.install][INFO  ] note that some dependencies *will not* be removed because they can cause issues with qemu-kvm
[ceph_deploy.install][INFO  ] like: librbd1 and librados2
[ceph_deploy.install][DEBUG ] Uninstalling on cluster ceph hosts slave1
[ceph_deploy.install][DEBUG ] Detecting platform for host slave1 ...
[slave1][DEBUG ] connected to host: slave1 
[slave1][DEBUG ] detect platform information from remote host
[ceph_deploy][ERROR ] UnsupportedPlatform: Platform is not supported: Kylin juniper 4.0.2
```
2. kylin os info 
```
root@slave1:~# cat /etc/os-release
NAME="Kylin"
VERSION="4.0.2 (juniper)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Kylin 4.0.2"
VERSION_ID="4.0.2"
HOME_URL="http://www.kylinos.cn/"
SUPPORT_URL="http://www.kylinos.cn/content/service/service.html"
BUG_REPORT_URL="http://www.kylinos.cn/"
UBUNTU_CODENAME=juniper
```
3. After modifying the file to add support：
```
root@slave1:/tmp# ceph-deploy -v uninstall slave1 
[ceph_deploy.conf][DEBUG ] found configuration file at: /root/.cephdeploy.conf
[ceph_deploy.cli][INFO  ] Invoked (2.0.1): /usr/bin/ceph-deploy -v uninstall slave1
[ceph_deploy.cli][INFO  ] ceph-deploy options:
[ceph_deploy.cli][INFO  ]  username                      : None
[ceph_deploy.cli][INFO  ]  verbose                       : True
[ceph_deploy.cli][INFO  ]  overwrite_conf                : False
[ceph_deploy.cli][INFO  ]  quiet                         : False
[ceph_deploy.cli][INFO  ]  cd_conf                       : <ceph_deploy.conf.cephdeploy.Conf instance at 0x7f9c98a1b8>
[ceph_deploy.cli][INFO  ]  cluster                       : ceph
[ceph_deploy.cli][INFO  ]  host                          : ['slave1']
[ceph_deploy.cli][INFO  ]  func                          : <function uninstall at 0x7f9cb1bb18>
[ceph_deploy.cli][INFO  ]  ceph_conf                     : None
[ceph_deploy.cli][INFO  ]  default_release               : False
[ceph_deploy.install][INFO  ] note that some dependencies *will not* be removed because they can cause issues with qemu-kvm
[ceph_deploy.install][INFO  ] like: librbd1 and librados2
[ceph_deploy.install][DEBUG ] Uninstalling on cluster ceph hosts slave1
[ceph_deploy.install][DEBUG ] Detecting platform for host slave1 ...
[slave1][DEBUG ] connected to host: slave1 
[slave1][DEBUG ] detect platform information from remote host
[slave1][DEBUG ] detect machine type
[ceph_deploy.install][INFO  ] Distro info: Kylin 4.0.2 juniper
[slave1][INFO  ] Uninstalling Ceph on slave1
[slave1][INFO  ] Running command: env DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical apt-get --assume-yes -q -f --force-yes remove ceph ceph-mds ceph-common ceph-fs-common radosgw
[slave1][DEBUG ] 正在读取软件包列表...
[slave1][DEBUG ] 正在分析软件包的依赖关系树...
[slave1][DEBUG ] 正在读取状态信息...
[slave1][DEBUG ] 软件包 ceph-fs-common 未安装，所以不会被卸载
[slave1][DEBUG ] 软件包 ceph 未安装，所以不会被卸载
[slave1][DEBUG ] 软件包 ceph-mds 未安装，所以不会被卸载
[slave1][DEBUG ] 软件包 radosgw 未安装，所以不会被卸载
[slave1][DEBUG ] 软件包 ceph-common 未安装，所以不会被卸载
[slave1][DEBUG ] 下列软件包是自动安装的并且现在不需要了：
[slave1][DEBUG ]   btrfs-tools cryptsetup-bin cython3 dmeventd formencode-i18n gdisk
[slave1][DEBUG ]   libboost-iostreams1.58.0 libboost-program-options1.58.0
[slave1][DEBUG ]   libboost-random1.58.0 libboost-regex1.58.0 libboost-system1.58.0
[slave1][DEBUG ]   libboost-thread1.58.0 libdevmapper-event1.02.1 libfcgi0ldbl libfuse-dev
[slave1][DEBUG ]   liblvm2app2.2 liblvm2cmd2.02 libpcre16-3 libpcre3-dev libpcre32-3
[slave1][DEBUG ]   libpcrecpp0v5 libreadline5 libselinux1-dev libsepol1-dev lvm2 python-bs4
[slave1][DEBUG ]   python-cherrypy3 python-dnspython python-flask python-formencode
[slave1][DEBUG ]   python-itsdangerous python-logutils python-mako python-paste
[slave1][DEBUG ]   python-pastedeploy python-pastedeploy-tpl python-pecan python-repoze.lru
[slave1][DEBUG ]   python-routes python-simplegeneric python-singledispatch python-tempita
[slave1][DEBUG ]   python-waitress python-webob python-webtest python-werkzeug
[slave1][DEBUG ]   python3-pkg-resources python3-setuptools python3-virtualenv virtualenv
[slave1][DEBUG ]   xfslibs-dev xfsprogs
[slave1][DEBUG ] 使用'apt autoremove'来卸载它(它们)。
[slave1][DEBUG ] 升级了 0 个软件包，新安装了 0 个软件包，要卸载 0 个软件包，有 291 个软件包未被升级。
```