### PR TITLE
add support for openeuler

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -97,6 +97,7 @@ def _get_distro(distro, fallback=None, use_rhceph=False):
         'oracle': centos,
         'redhat': centos,
         'fedora': fedora,
+        'openeuler':fedora,
         'suse': suse,
         'virtuozzo': centos,
         'arch': arch,

--- a/ceph_deploy/tests/unit/hosts/test_hosts.py
+++ b/ceph_deploy/tests/unit/hosts/test_hosts.py
@@ -431,3 +431,7 @@ class TestGetDistro(object):
     def test_get_altlinux(self):
         result = hosts._get_distro('ALT Linux')
         assert result.__name__.endswith('alt')
+
+    def test_get_openeulerlinux(self):
+        result = hosts._get_distro('Openeuler')
+        assert result.__name__.endswith('fedora')


### PR DESCRIPTION
os_path http://117.78.1.88:82/dailybuilds/openeuler/mainline/openEuler-20.03-LTS/
my test environment is Kunpeng 920s

[root@openeuler ~]# cat /etc/os-release 
NAME="openEuler"
VERSION="20.03 (LTS)"
ID="openEuler"
VERSION_ID="20.03"
PRETTY_NAME="openEuler 20.03 (LTS)"
ANSI_COLOR="0;31"

[root@openeuler ~]# ceph-deploy new openeuler
[ceph_deploy.conf][DEBUG ] found configuration file at: /root/.cephdeploy.conf
[ceph_deploy.cli][INFO  ] Invoked (2.0.1): /usr/bin/ceph-deploy new openeuler
[ceph_deploy.cli][INFO  ] ceph-deploy options:
[ceph_deploy.cli][INFO  ]  username                      : None
[ceph_deploy.cli][INFO  ]  verbose                       : False
[ceph_deploy.cli][INFO  ]  overwrite_conf                : False
[ceph_deploy.cli][INFO  ]  quiet                         : False
[ceph_deploy.cli][INFO  ]  cd_conf                       : <ceph_deploy.conf.cephdeploy.Conf instance at 0xffffa251e908>
[ceph_deploy.cli][INFO  ]  cluster                       : ceph
[ceph_deploy.cli][INFO  ]  ssh_copykey                   : True
[ceph_deploy.cli][INFO  ]  mon                           : ['openeuler']
[ceph_deploy.cli][INFO  ]  func                          : <function new at 0xffffa24fa488>
[ceph_deploy.cli][INFO  ]  public_network                : None
[ceph_deploy.cli][INFO  ]  ceph_conf                     : None
[ceph_deploy.cli][INFO  ]  cluster_network               : None
[ceph_deploy.cli][INFO  ]  default_release               : False
[ceph_deploy.cli][INFO  ]  fsid                          : None
[ceph_deploy.new][DEBUG ] Creating new cluster named ceph
[ceph_deploy.new][INFO  ] making sure passwordless SSH succeeds
[openeuler][DEBUG ] connected to host: openeuler 
[openeuler][DEBUG ] detect platform information from remote host
[openeuler][DEBUG ] detect machine type
[openeuler][DEBUG ] find the location of an executable
[openeuler][INFO  ] Running command: /usr/sbin/ip link show
[openeuler][INFO  ] Running command: /usr/sbin/ip addr show
[openeuler][DEBUG ] IP addresses found: [u'192.168.122.1', u'192.168.26.184']
[ceph_deploy.new][DEBUG ] Resolving host openeuler
[ceph_deploy.new][DEBUG ] Monitor openeuler at 192.168.26.184
[ceph_deploy.new][DEBUG ] Monitor initial members are ['openeuler']
[ceph_deploy.new][DEBUG ] Monitor addrs are ['192.168.26.184']
[ceph_deploy.new][DEBUG ] Creating a random mon key...
[ceph_deploy.new][DEBUG ] Writing monitor keyring to ceph.mon.keyring...
[ceph_deploy.new][DEBUG ] Writing initial config to ceph.conf...

