### PR TITLE
Fix compatibility with Python 3.8

### DIFF
--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -13,8 +13,13 @@ import re
 
 def platform_information(_linux_distribution=None):
     """ detect platform information from remote host """
-    linux_distribution = _linux_distribution or platform.linux_distribution
-    distro, release, codename = linux_distribution()
+    distro = release = codename = None
+    try:
+        linux_distribution = _linux_distribution or platform.linux_distribution
+        distro, release, codename = linux_distribution()
+    except AttributeError:
+        # NOTE: py38 does not have platform.linux_distribution
+        pass
     if not distro:
         distro, release, codename = parse_os_release()
     if not codename and 'debian' in distro.lower():  # this could be an empty string in Debian


### PR DESCRIPTION
The deprecated platform.linux_distribution function was removed
in Python 3.8 - fallback to using parse_os_release if the function
is not found.

Signed-off-by: James Page <james.page@ubuntu.com>