### PR TITLE
doc: fix the link previously pointing to http://ceph.com/ceph-deploy/…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ If you set up and tear down Ceph clusters a lot, and want minimal
 extra bureaucracy, this is for you.
 
 This ``README`` provides a brief overview of ceph-deploy, for thorough
-documentation please go to http://ceph.com/ceph-deploy/docs
+documentation please go to https://docs.ceph.com/projects/ceph-deploy/en/latest/
 
 .. _what this tool is not:
 


### PR DESCRIPTION
…docs

after migrating to RTD, all link changed. so update this one accordingly

Signed-off-by: Kefu Chai <tchaikov@gmail.com>