### PR TITLE
debian: drop unnecessary Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,12 +16,7 @@ Vcs-Browser: https://github.com/ceph/ceph-deploy
 
 Package: ceph-deploy
 Architecture: all
-Depends: python3,
-         python3-argparse,
-         python3-configparser,
-         python3-setuptools,
-         python3-remoto,
-         ${misc:Depends},
+Depends: ${misc:Depends},
          ${python3:Depends}
 Description:  Ceph-deploy is an easy to use configuration tool
  for the Ceph distributed storage system.


### PR DESCRIPTION
subvar "${python3:Depends}" is able to fill it with the proper deps.

after this change, the depends looks like:

dpkg -I ../ceph-deploy_2.0.1_all.deb | grep Depends
 Depends: python2:any, python3-remoto, python3:any

as in python3, none of

    python3-argparse
    python3-configparser
    python3-setuptools

is needed at runtime.

Signed-off-by: Kefu Chai <kchai@redhat.com>