### PR TITLE
fix install ceph release bug

### DIFF
--- a/ceph_deploy/hosts/centos/install.py
+++ b/ceph_deploy/hosts/centos/install.py
@@ -94,7 +94,7 @@ def install(distro, version_kind, version, adjust_repos, **kw):
                     'yum',
                     'install',
                     '-y',
-                    '{url}noarch/ceph-release-1-0.{dist}.noarch.rpm'.format(url=url, dist=dist),
+                    '{url}noarch/ceph-release-1-1.{dist}.noarch.rpm'.format(url=url, dist=dist),
                 ],
             )
 


### PR DESCRIPTION
ceph-release has updated from 1.0 to 1.1, fix it

Fix: https://tracker.ceph.com/issues/49620

Signed-off-by: Dai Zhiwei daizhiwei3@huawei.com
Signed-off-by: luo rixin luorixin@huawei.com