### PR TITLE
Added support for endeavouros

### DIFF
--- a/ceph_deploy/hosts/__init__.py
+++ b/ceph_deploy/hosts/__init__.py
@@ -70,7 +70,7 @@ def get(hostname,
     module.is_rpm = module.normalized_name in ['redhat', 'centos',
                                                'fedora', 'scientific', 'suse', 'oracle', 'virtuozzo', 'alt']
     module.is_deb = module.normalized_name in ['debian', 'ubuntu']
-    module.is_pkgtarxz = module.normalized_name in ['arch']
+    module.is_pkgtarxz = module.normalized_name in ['arch', 'endeavouros']
     module.is_swupd = module.normalized_name in ['clear']
     module.release = release
     module.codename = codename
@@ -102,6 +102,7 @@ def _get_distro(distro, fallback=None, use_rhceph=False):
         'suse': suse,
         'virtuozzo': centos,
         'arch': arch,
+        'endeavouros': arch,
         'alt': alt,
         'clear': clear
         }
@@ -128,7 +129,7 @@ def _normalized_distro_name(distro):
         return 'ubuntu'
     elif distro.startswith('virtuozzo'):
         return 'virtuozzo'
-    elif distro.startswith('arch'):
+    elif distro.startswith(('arch', 'endeavouros')):
         return 'arch'
     elif distro.startswith(('alt', 'altlinux', 'basealt', 'alt linux')):
         return 'alt'

--- a/ceph_deploy/hosts/remotes.py
+++ b/ceph_deploy/hosts/remotes.py
@@ -45,6 +45,8 @@ def platform_information(_linux_distribution=None):
         codename = 'oracle'
     if not codename and 'virtuozzo linux' in distro.lower():  # this could be an empty string in Virtuozzo linux
         codename = 'virtuozzo'
+    if not codename and 'endeavouros' in distro.lower():  # this could be an empty string in Arch linux
+        codename = 'arch'
     if not codename and 'arch' in distro.lower():  # this could be an empty string in Arch linux
         codename = 'arch'
 


### PR DESCRIPTION
EndavourOS is a relatively recent sub distribution of Arch Linux. The distribution provides minor modifications to Arch Linux with most of the packages coming from the Arch Linux repositories, making it a great distribution for people like myself who have installed Arch themselves but do not want to do it for every install they do.