### PR TITLE
Check if systemd is available for ceph-volume

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -199,6 +199,8 @@ def create_osd(
         '--%s' % storetype,
         '--data', data
     ]
+    if not system.is_systemd(conn):
+        args.append('--no-systemd')
     if zap:
         LOG.warning('zapping is no longer supported when preparing')
     if dmcrypt:


### PR DESCRIPTION
When using the init system different from systemd:
-->  FileNotFoundError: [Errno 2] No such file or directory: 'systemctl': 'systemctl' 

Run ceph-volume with --no-systemd option if there is no systemd