### PR TITLE
python3 strings are Unicode already, so no need to .decode() for python3

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -372,7 +372,9 @@ def disk_list(args, cfg):
             command,
         )
         for line in out:
-            line = line.decode('utf-8')
+            _decode = getattr(line, 'decode', None)
+            if _decode:
+                line = _decode('utf-8')
             if line.startswith('Disk /'):
                 distro.conn.logger.info(line)
 


### PR DESCRIPTION
Using duck typing to decide -- if there is a .decode() method, then we assume python2 and apply it; doing nothing otherwise